### PR TITLE
Enable explicit API mode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ kotlin {
         }
     }
 
-//    explicitApi = ExplicitApiMode.Warning
+    explicitApi()
     compilerOptions {
         freeCompilerArgs.add("-Xexpect-actual-classes")
         freeCompilerArgs.add("-opt-in=kotlinx.cinterop.BetaInteropApi")

--- a/src/commonMain/kotlin/com/lightningkite/reactive/context/CalculationContext.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/context/CalculationContext.kt
@@ -44,7 +44,7 @@ public interface StatusListener : CoroutineContext.Element {
      * @param status The reactive status of the process
      * @return A [Release] lambda to stop listening to the process
      */
-    fun watchBackgroundProcess(status: Reactive<*>): Release
+    public fun watchBackgroundProcess(status: Reactive<*>): Release
 
     /**
      * Called when a reactive calculation is happening in the foreground, so this listener can respond accordingly.
@@ -55,7 +55,7 @@ public interface StatusListener : CoroutineContext.Element {
      * @param status The reactive status of the process
      * @return A [Release] lambda to stop listening to the process
      */
-    fun watchForegroundProcess(status: Reactive<*>): Release = watchBackgroundProcess(status)
+    public fun watchForegroundProcess(status: Reactive<*>): Release = watchBackgroundProcess(status)
 }
 
 /**
@@ -76,7 +76,7 @@ public interface StatusListener : CoroutineContext.Element {
  *
  * @param action The cleanup action to execute when the scope completes
  */
-fun CoroutineScope.onRemove(action: () -> Unit) {
+public fun CoroutineScope.onRemove(action: () -> Unit) {
     coroutineContext[CoroutineName.Key]
     this.coroutineContext[Job]?.invokeOnCompletion { action() }
 }
@@ -221,7 +221,7 @@ fun CoroutineScope.onRemove(action: () -> Unit) {
 public sealed interface ReactiveCoroutineScope : CoroutineScope
 
 @Deprecated("No longer needed", ReplaceWith("CoroutineScope"))
-typealias CalculationContext = CoroutineScope
+public typealias CalculationContext = CoroutineScope
 
 /**
  * Checks whether this [CoroutineScope]'s dispatcher is a main thread dispatcher.
@@ -238,7 +238,7 @@ typealias CalculationContext = CoroutineScope
  * ```
  */
 @OptIn(ExperimentalStdlibApi::class)
-val CoroutineScope.requireMainThread: Boolean get() = coroutineContext[CoroutineDispatcher.Key] is MainCoroutineDispatcher
+public val CoroutineScope.requireMainThread: Boolean get() = coroutineContext[CoroutineDispatcher.Key] is MainCoroutineDispatcher
 
 /**
  * Executes the given [action] on the thread associated with this [CoroutineScope]'s dispatcher.
@@ -277,7 +277,7 @@ val CoroutineScope.requireMainThread: Boolean get() = coroutineContext[Coroutine
  * @param action The action to execute on this scope's thread
  */
 @OptIn(ExperimentalStdlibApi::class)
-fun CoroutineScope.onThread(action: () -> Unit) {
+public fun CoroutineScope.onThread(action: () -> Unit) {
     val d = coroutineContext[CoroutineDispatcher.Key] ?: return action()
     if (d.isDispatchNeeded(coroutineContext)) {
         d.dispatch(coroutineContext, Runnable(action))
@@ -293,4 +293,4 @@ fun CoroutineScope.onThread(action: () -> Unit) {
  * helping prevent accidental nesting of reactive contexts and providing better IDE support.
  */
 @DslMarker
-annotation class ReactiveDsl
+public annotation class ReactiveDsl

--- a/src/commonMain/kotlin/com/lightningkite/reactive/context/CoroutineScopeHelpers.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/context/CoroutineScopeHelpers.kt
@@ -24,9 +24,9 @@ import kotlin.time.Duration.Companion.milliseconds
  * Interface for helper functions which require an additional [CoroutineScope] context. This will eventually
  * be removed in favor of context receivers.
  * */
-interface CoroutineScopeHelpers : CoroutineScope {
+public interface CoroutineScopeHelpers : CoroutineScope {
     @ReactiveDsl
-    operator fun <T, IGNORED> ((T) -> IGNORED).invoke(actionToCalculate: ReactiveContext.() -> T) =
+    public operator fun <T, IGNORED> ((T) -> IGNORED).invoke(actionToCalculate: ReactiveContext.() -> T): TypedReactiveContext<IGNORED> =
         this@CoroutineScopeHelpers.reactive(action = { this@invoke(actionToCalculate(this)) })
 
     /**
@@ -46,7 +46,7 @@ interface CoroutineScopeHelpers : CoroutineScope {
      * ```
      * */
     @ReactiveDsl
-    operator fun <T> KMutableProperty0<T>.invoke(actionToCalculate: ReactiveContext.() -> T) = this@CoroutineScopeHelpers.reactive(action = { set(actionToCalculate(this)) })
+    public operator fun <T> KMutableProperty0<T>.invoke(actionToCalculate: ReactiveContext.() -> T): TypedReactiveContext<Unit> = this@CoroutineScopeHelpers.reactive(action = { set(actionToCalculate(this)) })
 
 
     /**
@@ -69,7 +69,7 @@ interface CoroutineScopeHelpers : CoroutineScope {
      * actually optimize and cut out the overhead of a full `reactive` context.
      * */
     @ReactiveDsl
-    infix fun <T> KMutableProperty0<T>.bind(reactive: Reactive<T>) {
+    public infix fun <T> KMutableProperty0<T>.bind(reactive: Reactive<T>) {
         if (reactive is ReactiveValue<T>) { // I did benchmarks, this is just as fast as overloading and easier to use.
             val release = reactive.addAndRunListener { this@bind.set(reactive.value) }
             // no need for status listener since result is infallible
@@ -89,7 +89,7 @@ interface CoroutineScopeHelpers : CoroutineScope {
      * Changes to either reactive value will propagate to the other.
      */
     @ReactiveDsl
-    infix fun <T> MutableReactive<T>.bind(master: MutableReactive<T>) {
+    public infix fun <T> MutableReactive<T>.bind(master: MutableReactive<T>) {
         val reportTo = RawReactive(ReactiveState(Unit))
         coroutineContext[StatusListener]?.watchBackgroundProcess(reportTo)
         launch {
@@ -127,25 +127,25 @@ interface CoroutineScopeHelpers : CoroutineScope {
      * Debounces listener notifications by [timeMs] milliseconds using this scope. State is always current.
      * @see DebounceReactive
      */
-    fun <T> Reactive<T>.debounce(timeMs: Long): Reactive<T> = DebounceReactive(this, this@CoroutineScopeHelpers, timeMs.milliseconds)
+    public fun <T> Reactive<T>.debounce(timeMs: Long): Reactive<T> = DebounceReactive(this, this@CoroutineScopeHelpers, timeMs.milliseconds)
 
     /**
      * Debounces listener notifications by [duration] using this scope. State is always current.
      * @see DebounceReactive
      */
-    fun <T> Reactive<T>.debounce(duration: Duration): Reactive<T> = DebounceReactive(this, this@CoroutineScopeHelpers, duration)
+    public fun <T> Reactive<T>.debounce(duration: Duration): Reactive<T> = DebounceReactive(this, this@CoroutineScopeHelpers, duration)
 
     /**
      * Debounces listener notifications by [timeMs] milliseconds using this scope.
      * @see DebounceListenable
      */
-    fun Listenable.debounce(timeMs: Long): Listenable = DebounceListenable(this, this@CoroutineScopeHelpers, timeMs.milliseconds)
+    public fun Listenable.debounce(timeMs: Long): Listenable = DebounceListenable(this, this@CoroutineScopeHelpers, timeMs.milliseconds)
 
     /**
      * Debounces listener notifications by [duration] using this scope.
      * @see DebounceListenable
      */
-    fun Listenable.debounce(duration: Duration): Listenable = DebounceListenable(this, this@CoroutineScopeHelpers, duration)
+    public fun Listenable.debounce(duration: Duration): Listenable = DebounceListenable(this, this@CoroutineScopeHelpers, duration)
 }
 
 @OptIn(ExperimentalStdlibApi::class)

--- a/src/commonMain/kotlin/com/lightningkite/reactive/context/CoroutineTools.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/context/CoroutineTools.kt
@@ -18,7 +18,7 @@ import kotlin.coroutines.resumeWithException
 
 
 @OptIn(ExperimentalStdlibApi::class)
-fun CoroutineScope.load(context: CoroutineContext = EmptyCoroutineContext, action: suspend () -> Unit): Job {
+public fun CoroutineScope.load(context: CoroutineContext = EmptyCoroutineContext, action: suspend () -> Unit): Job {
     val state = RawReactive<Unit>()
     val result = launch(
         context,
@@ -35,8 +35,8 @@ fun CoroutineScope.load(context: CoroutineContext = EmptyCoroutineContext, actio
     return result
 }
 
-class WaitGate(permit: Boolean = false) {
-    var permit: Boolean = permit
+public class WaitGate(permit: Boolean = false) {
+    public var permit: Boolean = permit
         set(value) {
             field = value
             if (value) {
@@ -46,18 +46,18 @@ class WaitGate(permit: Boolean = false) {
                 continuations.clear()
             }
         }
-    fun permitOnce() {
+    public fun permitOnce() {
         permit = true
         permit = false
     }
-    val continuations = ArrayList<Continuation<Unit>>()
-    suspend fun await(): Unit {
+    private val continuations = ArrayList<Continuation<Unit>>()
+    public suspend fun await(): Unit {
         if (permit) return
         else return suspendCancellableCoroutine {
             continuations.add(it)
         }
     }
-    fun abandon() {
+    public fun abandon() {
         for (continuation in continuations) {
             continuation.resumeWithException(CancellationException("abandoned as requested"))
         }

--- a/src/commonMain/kotlin/com/lightningkite/reactive/context/DependencyChangeListener.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/context/DependencyChangeListener.kt
@@ -8,13 +8,13 @@ import com.lightningkite.reactive.core.addAndRunListener
 import kotlinx.coroutines.*
 import kotlin.coroutines.*
 
-abstract class DependencyChangeListener : DependencyTracker(), CoroutineContext.Element {
+public abstract class DependencyChangeListener : DependencyTracker(), CoroutineContext.Element {
     override val key: CoroutineContext.Key<DependencyChangeListener> get() = Key
 
-    object Key : CoroutineContext.Key<DependencyChangeListener>
+    public object Key : CoroutineContext.Key<DependencyChangeListener>
 
-    abstract fun onDependencyChange()
-    open fun onDependencyNotReady() = onDependencyChange()
+    public abstract fun onDependencyChange()
+    public open fun onDependencyNotReady(): Unit = onDependencyChange()
 }
 
 private fun <T> Continuation<T>.resumeState(state: ReactiveState<T>) {
@@ -25,7 +25,7 @@ private fun <T> Continuation<T>.resumeState(state: ReactiveState<T>) {
     )
 }
 
-suspend fun rerunOn(listenable: Listenable) {
+public suspend fun rerunOn(listenable: Listenable) {
     currentCoroutineContext()[DependencyChangeListener.Key]?.let {
         if (it.existingDependency(listenable) == null) {
             it.registerDependency(listenable, listenable.addListener { it.onDependencyChange() })
@@ -33,11 +33,11 @@ suspend fun rerunOn(listenable: Listenable) {
     }
 }
 
-suspend inline operator fun <T> Reactive<T>.invoke(): T = await()
-suspend inline operator fun <T> ReactiveValue<T>.invoke(): T = await()
-suspend inline fun <T> Reactive<T>.exception(): Exception? = state { it.exception }
+public suspend inline operator fun <T> Reactive<T>.invoke(): T = await()
+public suspend inline operator fun <T> ReactiveValue<T>.invoke(): T = await()
+public suspend inline fun <T> Reactive<T>.exception(): Exception? = state { it.exception }
 
-suspend fun <T, V> Reactive<T>.state(get: (ReactiveState<T>) -> V): V {
+public suspend fun <T, V> Reactive<T>.state(get: (ReactiveState<T>) -> V): V {
     return currentCoroutineContext()[DependencyChangeListener.Key]?.let {
         // and the value is ready to go, just add the listener and proceed with the value.
         var last = state.let(get)
@@ -56,7 +56,7 @@ suspend fun <T, V> Reactive<T>.state(get: (ReactiveState<T>) -> V): V {
     } ?: state.let(get)
 }
 
-suspend fun <T> Reactive<T>.state(): ReactiveState<T> {
+public suspend fun <T> Reactive<T>.state(): ReactiveState<T> {
     return currentCoroutineContext()[DependencyChangeListener.Key]?.let {
         // and the value is ready to go, just add the listener and proceed with the value.
         var last = state
@@ -75,7 +75,7 @@ suspend fun <T> Reactive<T>.state(): ReactiveState<T> {
     } ?: state
 }
 
-suspend fun <T> ReactiveValue<T>.await(): T {
+public suspend fun <T> ReactiveValue<T>.await(): T {
     return currentCoroutineContext()[DependencyChangeListener.Key]?.let {
         // and the value is ready to go, just add the listener and proceed with the value.
         var last = value
@@ -94,7 +94,7 @@ suspend fun <T> ReactiveValue<T>.await(): T {
     } ?: value
 }
 
-suspend fun <T> Reactive<T>.await(): T {
+public suspend fun <T> Reactive<T>.await(): T {
     return currentCoroutineContext()[DependencyChangeListener.Key]?.let {
         var cont: Continuation<T>? = null
         if (it.existingDependency(this) == null) {
@@ -138,7 +138,7 @@ suspend fun <T> Reactive<T>.await(): T {
  * source's own nature, as with a `Signal` - is keeping that value current. Only [ReactiveState.notActive]
  * and notReady require listening, and the subscription is released as soon as a value arrives.
  */
-suspend fun <T> Reactive<T>.awaitOnce(): T {
+public suspend fun <T> Reactive<T>.awaitOnce(): T {
     val state = state
     @Suppress("DEPRECATION")
     return if (state.ready) state.get()

--- a/src/commonMain/kotlin/com/lightningkite/reactive/context/DependencyTracker.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/context/DependencyTracker.kt
@@ -1,6 +1,6 @@
 package com.lightningkite.reactive.context
 
-abstract class DependencyTracker {
+public abstract class DependencyTracker {
     private val dependencies = ArrayList<Pair<Any, () -> Unit>>()
     private val usedDependencies = ArrayList<Any>()
 
@@ -19,7 +19,7 @@ abstract class DependencyTracker {
      * so the fast-path alignment above holds even when a call site re-reads an earlier dependency.
      */
     @Suppress("UNCHECKED_CAST")
-    fun <T : Any> existingDependency(listenable: T): T? {
+    public fun <T : Any> existingDependency(listenable: T): T? {
         val index = usedDependencies.size
         if (index < dependencies.size) {
             val maybe = dependencies[index].first
@@ -33,11 +33,11 @@ abstract class DependencyTracker {
         return found
     }
 
-    fun registerDependency(any: Any, remove: () -> Unit) {
+    public fun registerDependency(any: Any, remove: () -> Unit) {
         this.dependencies += any to remove
     }
 
-    open fun cancel() {
+    public open fun cancel() {
         dependencies.forEach { it.second() }
         dependencies.clear()
     }

--- a/src/commonMain/kotlin/com/lightningkite/reactive/context/ReactiveContext.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/context/ReactiveContext.kt
@@ -32,7 +32,7 @@ import kotlin.coroutines.CoroutineContext
  * }
  * ```
  */
-typealias ReactiveContext = TypedReactiveContext<*>
+public typealias ReactiveContext = TypedReactiveContext<*>
 
 /**
  * Implements the core logic for a single reactive calculation, managing its dependencies and lifecycle.
@@ -154,20 +154,20 @@ typealias ReactiveContext = TypedReactiveContext<*>
  * @property reportTo The underlying [RawReactive] to report state updates to.
  * @property action The calculation logic to execute in this context.
  */
-class TypedReactiveContext<T>(
-    val scope: CoroutineScope,
-    val useLastWhileLoading: Boolean = false,
-    val reentrancyLimit: Int = 0,
+public class TypedReactiveContext<T>(
+    public val scope: CoroutineScope,
+    public val useLastWhileLoading: Boolean = false,
+    public val reentrancyLimit: Int = 0,
     private val reportTo: RawReactive<T> = RawReactive(),
-    val action: TypedReactiveContext<T>.() -> T
+    public val action: TypedReactiveContext<T>.() -> T
 ) : DependencyChangeListener(), ReactiveCoroutineScope, Reactive<T> by reportTo {
-    companion object
+    public companion object {}
 
     /**
      * Whether this context is currently active and tracking dependencies.
      * Set to false when [cancel] is called.
      */
-    var active = false
+    public var active: Boolean = false
         private set
 
     /**
@@ -180,7 +180,7 @@ class TypedReactiveContext<T>(
      * arrives through this path while the calculation is still running is indistinguishable from
      * the calculation triggering itself, and so spends [reentrancyLimit].
      */
-    val rerun: () -> Unit = ::startCalculation
+    public val rerun: () -> Unit = ::startCalculation
 
     /**
      * The current job for this calculation run.
@@ -229,7 +229,7 @@ class TypedReactiveContext<T>(
      * than recursing until the stack overflows, or livelocking under a dispatching scheduler. The
      * default limit of zero forbids self-triggering outright.
      */
-    fun startCalculation() {
+    public fun startCalculation() {
         active = true
         if (queued) return // Prevent duplicate queuing; the pending run will see the new state
         queued = true
@@ -324,7 +324,7 @@ class TypedReactiveContext<T>(
     /**
      * Starts using this [ResourceUse] and tracks it as a dependency in future loops.
      * */
-    fun use(resourceUse: ResourceUse) {
+    public fun use(resourceUse: ResourceUse) {
         if (existingDependency(resourceUse) != null) return
         registerDependency(resourceUse, resourceUse.beginUse())
     }
@@ -343,7 +343,7 @@ class TypedReactiveContext<T>(
      * }
      * ```
      */
-    fun rerunOn(listenable: Listenable) {
+    public fun rerunOn(listenable: Listenable) {
         if (existingDependency(listenable) != null) return
         registerDependency(listenable, listenable.addListener(rerun))
     }
@@ -383,7 +383,7 @@ class TypedReactiveContext<T>(
      * @return The current value of this reactive
      * @throws ReactiveLoading if the value is not ready
      */
-    operator fun <R> Reactive<R>.invoke(): R {
+    public operator fun <R> Reactive<R>.invoke(): R {
         if (existingDependency(this) == null) {
             registerDependency(this, addListener(rerun))
         }
@@ -407,7 +407,7 @@ class TypedReactiveContext<T>(
      * @return The non-null value
      * @throws ReactiveLoading if the value is null or not ready
      */
-    fun <R> Reactive<R?>.awaitNotNull(): R {
+    public fun <R> Reactive<R?>.awaitNotNull(): R {
         if (existingDependency(this) == null) {
             registerDependency(this, addListener(rerun))
         }
@@ -433,7 +433,7 @@ class TypedReactiveContext<T>(
      *
      * @return The current [ReactiveState]
      */
-    fun <R> Reactive<R>.state(): ReactiveState<R> {
+    public fun <R> Reactive<R>.state(): ReactiveState<R> {
         if (existingDependency(this) == null) {
             registerDependency(this, addListener(rerun))
         }
@@ -457,7 +457,7 @@ class TypedReactiveContext<T>(
      * @param get Function to extract a value from the [ReactiveState]
      * @return The transformed value
      */
-    fun <R, V> Reactive<R>.state(get: (ReactiveState<R>) -> V): V {
+    public fun <R, V> Reactive<R>.state(get: (ReactiveState<R>) -> V): V {
         var current: V = state.let(get)
         if (existingDependency(this) == null) {
             registerDependency(this, addListener {
@@ -501,7 +501,7 @@ class TypedReactiveContext<T>(
      * @return The value once it's ready
      * @throws ReactiveLoading if the value is not ready yet
      */
-    fun <T> Reactive<T>.once(): T {
+    public fun <T> Reactive<T>.once(): T {
         val key = existingDependency(Once(this)) ?: Once(this).also { key ->
             registerDependency(key, addListener { if (!key.have) rerun() })
         }
@@ -512,19 +512,19 @@ class TypedReactiveContext<T>(
 
     // Hack: fixes compiler weirdness around lambdas with 'this'
     @Suppress("NOTHING_TO_INLINE")
-    inline operator fun <T> (ReactiveContext.() -> T).invoke(): T = invoke(this@TypedReactiveContext)
+    public inline operator fun <T> (ReactiveContext.() -> T).invoke(): T = invoke(this@TypedReactiveContext)
 
     @Suppress("NOTHING_TO_INLINE")
-    inline operator fun <A, T> (ReactiveContext.(A) -> T).invoke(a: A): T = invoke(this@TypedReactiveContext, a)
+    public inline operator fun <A, T> (ReactiveContext.(A) -> T).invoke(a: A): T = invoke(this@TypedReactiveContext, a)
 
     @Suppress("NOTHING_TO_INLINE")
-    inline operator fun <A, B, T> (ReactiveContext.(A, B) -> T).invoke(a: A, b: B): T = invoke(this@TypedReactiveContext, a, b)
+    public inline operator fun <A, B, T> (ReactiveContext.(A, B) -> T).invoke(a: A, b: B): T = invoke(this@TypedReactiveContext, a, b)
 
     @Deprecated("Just use the invoke operator", ReplaceWith("this()"))
-    fun <T> Reactive<T>.await(): T = invoke()
+    public fun <T> Reactive<T>.await(): T = invoke()
 
     @Deprecated("Just use the once function", ReplaceWith("this.once()"))
-    fun <T> Reactive<T>.awaitOnce(): T = once()
+    public fun <T> Reactive<T>.awaitOnce(): T = once()
 
     // Suspending calculations
 
@@ -568,7 +568,7 @@ class TypedReactiveContext<T>(
      * @return The result of the calculation once complete
      * @throws ReactiveLoading if the calculation is not yet complete
      */
-    fun <T> async(identity: String, vararg dependencies: Any?, action: suspend () -> T): T {
+    public fun <T> async(identity: String, vararg dependencies: Any?, action: suspend () -> T): T {
         // action::class distinguishes call sites: two different `async(...) { }` call sites compile
         // to distinct anonymous classes, so folding it into the key stops two call sites that
         // happen to pass identical dependencies from colliding on the same cached calculation.
@@ -614,7 +614,7 @@ class TypedReactiveContext<T>(
      * @return The deferred value once available
      * @throws ReactiveLoading if the deferred is not yet complete
      */
-    operator fun <T> Deferred<T>.invoke(): T {
+    public operator fun <T> Deferred<T>.invoke(): T {
         val calc = SuspendCalculation<T>(this)
 
         // Reuse existing calculation if already running
@@ -671,7 +671,7 @@ class TypedReactiveContext<T>(
      * @return The latest emitted value
      * @throws ReactiveLoading if no value has been emitted yet (except for StateFlow)
      */
-    operator fun <T> Flow<T>.invoke(): T {
+    public operator fun <T> Flow<T>.invoke(): T {
         val new = FlowLoader(this)
 
         val existing = existingDependency(new)
@@ -775,7 +775,7 @@ class TypedReactiveContext<T>(
  * @see TypedReactiveContext for implementation details
  * @see reactiveSuspending for suspending calculations
  */
-fun <T> CoroutineScope.reactive(reentrancyLimit: Int = 0, action: ReactiveContext.() -> T): TypedReactiveContext<T> {
+public fun <T> CoroutineScope.reactive(reentrancyLimit: Int = 0, action: ReactiveContext.() -> T): TypedReactiveContext<T> {
     val trc = TypedReactiveContext(this, reentrancyLimit = reentrancyLimit, action = action)
     trc.startCalculation()
     coroutineContext[StatusListener]?.watchBackgroundProcess(trc)
@@ -801,7 +801,7 @@ fun <T> CoroutineScope.reactive(reentrancyLimit: Int = 0, action: ReactiveContex
  * @param action The calculation logic to run reactively.
  * @return A [TypedReactiveContext] managing the calculation and its dependencies.
  */
-inline fun CoroutineScope.reactive(crossinline onLoad: () -> Unit, crossinline action: ReactiveContext.() -> Unit): TypedReactiveContext<Unit> {
+public inline fun CoroutineScope.reactive(crossinline onLoad: () -> Unit, crossinline action: ReactiveContext.() -> Unit): TypedReactiveContext<Unit> {
     var wasLoadingLastTime = false
     return reactive {
         try {
@@ -827,7 +827,7 @@ inline fun CoroutineScope.reactive(crossinline onLoad: () -> Unit, crossinline a
  * @param action The calculation logic to run reactively.
  */
 @Deprecated("renamed to 'reactive'", ReplaceWith("this.reactive(action)"))
-fun CoroutineScope.reactiveScope(action: ReactiveContext.() -> Unit): ReactiveContext = reactive(action = action)
+public fun CoroutineScope.reactiveScope(action: ReactiveContext.() -> Unit): ReactiveContext = reactive(action = action)
 
 /**
  * Creates a [ReactiveContext] in which to run the provided [action] reactively, discarding the result, with support for loading state.
@@ -839,17 +839,17 @@ fun CoroutineScope.reactiveScope(action: ReactiveContext.() -> Unit): ReactiveCo
  * @param action The calculation logic to run reactively.
  */
 @Deprecated("renamed to 'reactive'", ReplaceWith("this.reactive(onLoad, action)"))
-inline fun CoroutineScope.reactiveScope(crossinline onLoad: () -> Unit, crossinline action: ReactiveContext.() -> Unit): ReactiveContext = reactive(onLoad = onLoad, action = action)
+public inline fun CoroutineScope.reactiveScope(crossinline onLoad: () -> Unit, crossinline action: ReactiveContext.() -> Unit): ReactiveContext = reactive(onLoad = onLoad, action = action)
 
 @InternalReactiveApi
-object ReactiveLoading : Throwable()
+public object ReactiveLoading : Throwable()
 
 /**
  * Thrown when a reactive calculation triggers its own re-execution, typically by writing to a
  * signal it also reads inside the same [reactive] block. This would otherwise recurse until the
  * stack overflows (or livelock under a dispatching scheduler), so it is surfaced as a clear error.
  */
-class ReactiveReentrancyException(context: ReactiveContext, reentrancyLimit: Int) : IllegalStateException(
+public class ReactiveReentrancyException(context: ReactiveContext, reentrancyLimit: Int) : IllegalStateException(
     if (reentrancyLimit <= 0)
         "A reactive calculation triggered its own re-execution ($context). This usually means the " +
                 "calculation wrote to a signal it also reads. Break the cycle so the calculation " +

--- a/src/commonMain/kotlin/com/lightningkite/reactive/context/ReactiveContextSuspending.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/context/ReactiveContextSuspending.kt
@@ -92,11 +92,11 @@ import kotlin.coroutines.CoroutineContext
  * @property reportTo The underlying [RawReactive] to report state updates to.
  * @property action The suspending calculation logic to execute in this context.
  */
-class ReactiveContextSuspending<T>(
-    val scope: CoroutineScope,
-    val useLastWhileLoading: Boolean = false,
+public class ReactiveContextSuspending<T>(
+    public val scope: CoroutineScope,
+    public val useLastWhileLoading: Boolean = false,
     private val reportTo: RawReactive<T> = RawReactive(),
-    val action: suspend ReactiveCoroutineScope.() -> T,
+    public val action: suspend ReactiveCoroutineScope.() -> T,
 ) : DependencyChangeListener(), ReactiveCoroutineScope, Reactive<T> by reportTo {
     /**
      * The job for the current calculation run's coroutine.
@@ -108,7 +108,7 @@ class ReactiveContextSuspending<T>(
      * Whether this context is currently active and tracking dependencies.
      * Set to false when [cancel] is called.
      */
-    var active = false
+    public var active: Boolean = false
         private set
 
     /**
@@ -161,7 +161,7 @@ class ReactiveContextSuspending<T>(
      * The calculation may complete synchronously (if already on correct dispatcher and no suspension points)
      * or asynchronously. If [useLastWhileLoading] is false, the state is set to notReady during async execution.
      */
-    fun startCalculation() {
+    public fun startCalculation() {
         active = true
         lastLoopJob?.cancel() // Cancel previous calculation if still running
 
@@ -310,7 +310,7 @@ class ReactiveContextSuspending<T>(
  * @see ReactiveContextSuspending for implementation details
  * @see reactive for non-suspending calculations
  */
-fun CoroutineScope.reactiveSuspending(action: suspend ReactiveCoroutineScope.() -> Unit) =
+public fun CoroutineScope.reactiveSuspending(action: suspend ReactiveCoroutineScope.() -> Unit): ReactiveContextSuspending<Unit> =
     ReactiveContextSuspending(this, action = action).also {
         it.startCalculation()
         coroutineContext[StatusListener.Key]?.watchBackgroundProcess(it)
@@ -326,7 +326,7 @@ fun CoroutineScope.reactiveSuspending(action: suspend ReactiveCoroutineScope.() 
  * @param action The suspending calculation logic to run reactively.
  * @return A [ReactiveContextSuspending] managing the calculation and its dependencies.
  */
-inline fun CoroutineScope.reactiveSuspending(crossinline onLoad: () -> Unit, noinline action: suspend ReactiveCoroutineScope.() -> Unit): ReactiveContextSuspending<Unit> {
+public inline fun CoroutineScope.reactiveSuspending(crossinline onLoad: () -> Unit, noinline action: suspend ReactiveCoroutineScope.() -> Unit): ReactiveContextSuspending<Unit> {
     return reactiveSuspending(action = action).also {
         it.addListener { if (!it.state.ready) onLoad() }.let(::onRemove)
     }

--- a/src/commonMain/kotlin/com/lightningkite/reactive/core/AppScope.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/core/AppScope.kt
@@ -1,12 +1,13 @@
 package com.lightningkite.reactive.core
 
+import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 
-val AppJob = SupervisorJob()
+public val AppJob: CompletableJob = SupervisorJob()
 
-val AppScope = CoroutineScope(AppJob + CoroutineExceptionHandler { coroutineContext, throwable ->
+public val AppScope: CoroutineScope = CoroutineScope(AppJob + CoroutineExceptionHandler { coroutineContext, throwable ->
     Reactive.reportException(throwable)
 } + Dispatchers.Main.immediate)

--- a/src/commonMain/kotlin/com/lightningkite/reactive/core/Draft.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/core/Draft.kt
@@ -24,28 +24,28 @@ import com.lightningkite.reactive.context.awaitOnce
  * draft.cancel() // discards changes and resets the draft. draft now reads '42' again.
  * ```
  */
-interface Draft<T> : ReactiveWithMutableValue<T> {
+public interface Draft<T> : ReactiveWithMutableValue<T> {
     /**
      * The current saved value that this [Draft] is buffering.
      *
      * NOTE: Manually setting values for [published] will not by-default update values in the draft buffer.
      * */
-    val published: MutableReactive<T>
+    public val published: MutableReactive<T>
 
     /**
      * Saves all changes made to this [Draft] to the published [MutableReactive]
      * */
-    suspend fun publish(): T
+    public suspend fun publish(): T
 
     /**
      * Discards all changes made to this [Draft] and reverts back to the [published] state
      * */
-    fun cancel()
+    public fun cancel()
 
     /**
      * Reads `true` if there are any differences between the [published] value and the value stored in the draft buffer.
      * */
-    val changesMade: Reactive<Boolean>
+    public val changesMade: Reactive<Boolean>
 }
 
 private class BaseDraft<T> private constructor(
@@ -67,14 +67,14 @@ private class BaseDraft<T> private constructor(
 /**
  * Creates a [Draft] using the specified [MutableReactive] as the published value.
  * */
-fun <T> Draft(published: MutableReactive<T>): Draft<T> = BaseDraft(published)
+public fun <T> Draft(published: MutableReactive<T>): Draft<T> = BaseDraft(published)
 
 /**
  * Creates a [Draft] where the published value is the provided [initialValue]
  * */
-fun <T> Draft(initialValue: T): Draft<T> = BaseDraft(Signal(initialValue))
+public fun <T> Draft(initialValue: T): Draft<T> = BaseDraft(Signal(initialValue))
 
 /**
  * Creates a [Draft] where the published value is calculated based off the provided [initialValue] calculation.
  * */
-fun <T> Draft(initialValue: ReactiveContext.() -> T): Draft<T> = BaseDraft(MutableRemember(useLastWhileLoading = true, initialValue = initialValue))
+public fun <T> Draft(initialValue: ReactiveContext.() -> T): Draft<T> = BaseDraft(MutableRemember(useLastWhileLoading = true, initialValue = initialValue))

--- a/src/commonMain/kotlin/com/lightningkite/reactive/core/InternalReactiveApi.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/core/InternalReactiveApi.kt
@@ -5,4 +5,4 @@ package com.lightningkite.reactive.core
     level = RequiresOptIn.Level.WARNING,
     message = "This may change, use it at your own risk"
 )
-annotation class InternalReactiveApi
+public annotation class InternalReactiveApi

--- a/src/commonMain/kotlin/com/lightningkite/reactive/core/MutableRemember.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/core/MutableRemember.kt
@@ -32,7 +32,7 @@ import kotlin.time.Duration
  *
  * @see remember
  */
-fun <T> mutableRemember(
+public fun <T> mutableRemember(
     useLastWhileLoading: Boolean = false,
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
     initialValue: ReactiveContext.() -> T
@@ -57,14 +57,14 @@ fun <T> mutableRemember(
  *
  * @see Remember
  */
-class MutableRemember<T>(
+public class MutableRemember<T>(
     private val stopListeningWhenOverridden: Boolean = true,
     private val useLastWhileLoading: Boolean = false,
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
     deactivationDelay: Duration? = null,
     initialValue: ReactiveContext.() -> T
 ): ReactiveWithMutableValue<T>, BaseReactive<T>() {
-    var overridden: Boolean = false
+    public var overridden: Boolean = false
         private set
 
     private val remember = Remember(coroutineContext, useLastWhileLoading, deactivationDelay, action = initialValue)
@@ -117,7 +117,7 @@ class MutableRemember<T>(
      * - This does not forcefully notify listeners. If the value calculated after resetting is the same as the previously set value,
      *   then no listeners will be notified.
      */
-    fun reset() {
+    public fun reset() {
         if (overridden) {
             overridden = false
             if (stopListeningWhenOverridden) startListening()

--- a/src/commonMain/kotlin/com/lightningkite/reactive/core/MutableRememberSuspending.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/core/MutableRememberSuspending.kt
@@ -33,7 +33,7 @@ import kotlin.time.Duration
  * @see rememberSuspending
  * @see mutableRemember
  */
-fun <T> mutableRememberSuspending(
+public fun <T> mutableRememberSuspending(
     useLastWhileLoading: Boolean = false,
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
     initialValue: suspend CoroutineScope.() -> T
@@ -58,14 +58,14 @@ fun <T> mutableRememberSuspending(
  *
  * @see [MutableRemember]
  */
-class MutableRememberSuspending<T>(
+public class MutableRememberSuspending<T>(
     private val stopListeningWhenOverridden: Boolean = true,
     private val useLastWhileLoading: Boolean = false,
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
     deactivationDelay: Duration? = null,
     initialValue: suspend CoroutineScope.() -> T
 ) : ReactiveWithMutableValue<T>, BaseReactive<T>() {
-    var overridden: Boolean = false
+    public var overridden: Boolean = false
         private set
 
     private val remember = RememberSuspending(coroutineContext, useLastWhileLoading, deactivationDelay, initialValue)
@@ -123,7 +123,7 @@ class MutableRememberSuspending<T>(
      * - This does not forcefully notify listeners. If the value calculated after resetting is the same as the previously set value,
      *   then no listeners will be notified.
      */
-    fun reset() {
+    public fun reset() {
         if (overridden) {
             overridden = false
             if (stopListeningWhenOverridden) startListening()

--- a/src/commonMain/kotlin/com/lightningkite/reactive/core/ReactiveMutableList.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/core/ReactiveMutableList.kt
@@ -6,10 +6,10 @@ import com.lightningkite.reactive.lensing.lens
 /**
  * A wrapper around [ArrayList] that signals its listeners whenever it is mutated
  * */
-class ReactiveMutableList<T>(private val list: ArrayList<T>): MutableList<T> by list, MutableReactiveValue<List<T>>, BaseListenable() {
-    constructor() : this(ArrayList<T>())
-    constructor(items: List<T>) : this(ArrayList(items))
-    constructor(vararg startingItems: T) : this(ArrayList(startingItems.asList()))
+public class ReactiveMutableList<T>(private val list: ArrayList<T>): MutableList<T> by list, MutableReactiveValue<List<T>>, BaseListenable() {
+    public constructor() : this(ArrayList<T>())
+    public constructor(items: List<T>) : this(ArrayList(items))
+    public constructor(vararg startingItems: T) : this(ArrayList(startingItems.asList()))
 
     override var value: List<T>
         get() = list
@@ -33,11 +33,11 @@ class ReactiveMutableList<T>(private val list: ArrayList<T>): MutableList<T> by 
     override fun removeAll(elements: Collection<T>): Boolean = signalChange { removeAll(elements) }
     override fun addAll(elements: Collection<T>): Boolean = signalChange { addAll(elements) }
     override fun addAll(index: Int, elements: Collection<T>): Boolean = signalChange { addAll(index, elements) }
-    override fun add(index: Int, element: T) = signal { add(index, element) }
+    override fun add(index: Int, element: T): Unit = signal { add(index, element) }
     override fun add(element: T): Boolean = signal { add(element) }
     override fun remove(element: T): Boolean = signalChange { remove(element) }
 
-    fun reactiveContains(element: T) = object : MutableReactiveValue<Boolean> {
+    public fun reactiveContains(element: T): MutableReactiveValue<Boolean> = object : MutableReactiveValue<Boolean> {
         private val lens = this@ReactiveMutableList.lens { element in it }
 
         override fun addListener(listener: () -> Unit): Release = lens.addListener(listener)

--- a/src/commonMain/kotlin/com/lightningkite/reactive/core/ReactiveMutableMap.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/core/ReactiveMutableMap.kt
@@ -5,8 +5,8 @@ import com.lightningkite.reactive.lensing.lens
 /**
  * A wrapper around [HashMap] that signals its listeners whenever it is mutated
  * */
-class ReactiveMutableMap<K, V>(private val map: HashMap<K, V>): MutableMap<K, V> by map, MutableReactiveValue<Map<K, V>>, BaseListenable() {
-    constructor() : this(HashMap())
+public class ReactiveMutableMap<K, V>(private val map: HashMap<K, V>): MutableMap<K, V> by map, MutableReactiveValue<Map<K, V>>, BaseListenable() {
+    public constructor() : this(HashMap())
 
     override var value: Map<K, V>
         get() = map
@@ -18,26 +18,26 @@ class ReactiveMutableMap<K, V>(private val map: HashMap<K, V>): MutableMap<K, V>
             }
         }
 
-    val reactiveEntries: ReactiveValue<Set<Map.Entry<K, V>>> =
+    public val reactiveEntries: ReactiveValue<Set<Map.Entry<K, V>>> =
         object : ReactiveValue<Set<Map.Entry<K, V>>>, Listenable by this {
             override val value: Set<Map.Entry<K, V>> get() = map.entries
         }
 
-    val reactiveKeys: ReactiveValue<Set<K>> =
+    public val reactiveKeys: ReactiveValue<Set<K>> =
         object : ReactiveValue<Set<K>>, Listenable by this {
             override val value: Set<K> get() = map.keys
         }
 
-    val reactiveValues: ReactiveValue<Collection<V>> =
+    public val reactiveValues: ReactiveValue<Collection<V>> =
         object : ReactiveValue<Collection<V>>, Listenable by this {
             override val value: Collection<V> get() = map.values
         }
 
     private inline fun <T> signal(operation: MutableMap<K, V>.()->T) = map.operation().also { invokeAllListeners() }
 
-    override fun clear() = signal { clear() }
+    override fun clear(): Unit = signal { clear() }
     override fun remove(key: K): V? = map.remove(key).also { if (it != null) invokeAllListeners() }
-    override fun putAll(from: Map<out K, V>) = signal { putAll(from) }
+    override fun putAll(from: Map<out K, V>): Unit = signal { putAll(from) }
     override fun put(key: K, value: V): V? = signal { put(key, value) }
 
     private inner class Element(private val key: K) : MutableReactiveValue<V?> {
@@ -53,5 +53,5 @@ class ReactiveMutableMap<K, V>(private val map: HashMap<K, V>): MutableMap<K, V>
             }
     }
 
-    fun getReactive(key: K): MutableReactiveValue<V?> = Element(key)
+    public fun getReactive(key: K): MutableReactiveValue<V?> = Element(key)
 }

--- a/src/commonMain/kotlin/com/lightningkite/reactive/core/ReactiveMutableSet.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/core/ReactiveMutableSet.kt
@@ -6,10 +6,10 @@ import com.lightningkite.reactive.lensing.lens
 /**
  * A wrapper around [LinkedHashSet] that signals its listeners whenever it is mutated
  * */
-class ReactiveMutableSet<T>(private val hashSet: LinkedHashSet<T>): MutableSet<T> by hashSet, MutableReactiveValue<Set<T>>, BaseListenable() {
-    constructor() : this(LinkedHashSet<T>())
-    constructor(items: Set<T>) : this(LinkedHashSet(items))
-    constructor(vararg startingItems: T) : this(LinkedHashSet(startingItems.toList()))
+public class ReactiveMutableSet<T>(private val hashSet: LinkedHashSet<T>): MutableSet<T> by hashSet, MutableReactiveValue<Set<T>>, BaseListenable() {
+    public constructor() : this(LinkedHashSet<T>())
+    public constructor(items: Set<T>) : this(LinkedHashSet(items))
+    public constructor(vararg startingItems: T) : this(LinkedHashSet(startingItems.toList()))
 
     override var value: Set<T>
         get() = hashSet
@@ -34,7 +34,7 @@ class ReactiveMutableSet<T>(private val hashSet: LinkedHashSet<T>): MutableSet<T
     override fun add(element: T): Boolean = signal { add(element) }
     override fun remove(element: T): Boolean = signal { remove(element) }
 
-    fun reactiveContains(element: T) = object : MutableReactiveValue<Boolean> {
+    public fun reactiveContains(element: T): MutableReactiveValue<Boolean> = object : MutableReactiveValue<Boolean> {
         private val lens = this@ReactiveMutableSet.lens { element in it }
 
         override fun addListener(listener: () -> Unit): Release = lens.addListener(listener)

--- a/src/commonMain/kotlin/com/lightningkite/reactive/core/ReactiveState.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/core/ReactiveState.kt
@@ -28,49 +28,49 @@ import kotlin.jvm.JvmInline
  */
 @JvmInline
 @OptIn(InternalReactiveApi::class)
-value class ReactiveState<out T>(val raw: T) {
-    inline val ready: Boolean get() = raw != InternalReactiveNotReady && raw != InternalReactiveNotActive
-    inline val success: Boolean get() = ready && raw !is InternalReactiveThrownException
+public value class ReactiveState<out T>(public val raw: T) {
+    public inline val ready: Boolean get() = raw != InternalReactiveNotReady && raw != InternalReactiveNotActive
+    public inline val success: Boolean get() = ready && raw !is InternalReactiveThrownException
 
     /** True when nothing is maintaining this value; see the [ReactiveState] docs. */
-    inline val notActive: Boolean get() = raw is InternalReactiveNotActive
+    public inline val notActive: Boolean get() = raw is InternalReactiveNotActive
 
-    inline fun <R> onSuccess(action: (T)->R): R? = handle(
+    public inline fun <R> onSuccess(action: (T)->R): R? = handle(
         success = { action(it) },
         exception = { null },
         notReady = { null }
     )
-    inline val exception: Exception? get() = (raw as? InternalReactiveThrownException)?.exception
+    public inline val exception: Exception? get() = (raw as? InternalReactiveThrownException)?.exception
 
     @Deprecated("Only use this if you are *Absolutely Sure* that there is a value ready to retrieve. Otherwise, use `handle`.")
-    fun get(): T = handle(
+    public fun get(): T = handle(
         success = { it },
         exception = { throw it },
         notReady = { throw NotReadyException() },
         notActive = { throw NotActiveException() }
     )
 
-    fun getOrNull(): T? = handle(
+    public fun getOrNull(): T? = handle(
         success = { it },
         exception = { null },
         notReady = { null }
     )
 
-    companion object Companion {
+    public companion object Companion {
         @Suppress("UNCHECKED_CAST")
-        val notReady: ReactiveState<Nothing> = ReactiveState<Any?>(InternalReactiveNotReady) as ReactiveState<Nothing>
+        public val notReady: ReactiveState<Nothing> = ReactiveState<Any?>(InternalReactiveNotReady) as ReactiveState<Nothing>
 
         /** No value, because nothing is maintaining one; see the [ReactiveState] docs. */
         @Suppress("UNCHECKED_CAST")
-        val notActive: ReactiveState<Nothing> = ReactiveState<Any?>(InternalReactiveNotActive) as ReactiveState<Nothing>
+        public val notActive: ReactiveState<Nothing> = ReactiveState<Any?>(InternalReactiveNotActive) as ReactiveState<Nothing>
 
         @Suppress("UNCHECKED_CAST")
-        fun <T> exception(exception: Exception) = (if(exception is CancellationException) notReady else ReactiveState<Any?>(InternalReactiveThrownException(exception))) as ReactiveState<T>
+        public fun <T> exception(exception: Exception): ReactiveState<T> = (if(exception is CancellationException) notReady else ReactiveState<Any?>(InternalReactiveThrownException(exception))) as ReactiveState<T>
         @Suppress("UNCHECKED_CAST")
-        fun <T> wrap(value: T) = ReactiveState<Any?>(InternalReactiveWrapper(value)) as ReactiveState<T>
+        public fun <T> wrap(value: T): ReactiveState<T> = ReactiveState<Any?>(InternalReactiveWrapper(value)) as ReactiveState<T>
     }
     @Suppress("UNCHECKED_CAST")
-    inline fun <B> map(mapper: (T)->B): ReactiveState<B> {
+    public inline fun <B> map(mapper: (T)->B): ReactiveState<B> {
         // notActive propagates like the other valueless states: a value derived from a source
         // nobody is maintaining is equally unmaintained.
         if(raw is InternalReactiveNotReady || raw is InternalReactiveNotActive || raw is InternalReactiveThrownException) return this as ReactiveState<B>
@@ -90,14 +90,14 @@ value class ReactiveState<out T>(val raw: T) {
      * value" and "there is no value yet" are the same thing to code that only wants to display or
      * wait for one. Use the four-argument overload to do something better, such as subscribing.
      */
-    inline fun <R> handle(
+    public inline fun <R> handle(
         success: (T)->R,
         exception: (Exception)->R,
         notReady: ()->R
     ): R = handle(success, exception, notReady, notReady)
 
     @Suppress("UNCHECKED_CAST")
-    inline fun <R> handle(
+    public inline fun <R> handle(
         success: (T)->R,
         exception: (Exception)->R,
         notReady: ()->R,
@@ -112,7 +112,7 @@ value class ReactiveState<out T>(val raw: T) {
         }
     }
 
-    fun asResult(): Result<T> = handle(
+    public fun asResult(): Result<T> = handle(
         success = { Result.success(it) },
         exception = { Result.failure(it) },
         notReady = { Result.failure(NotReadyException()) },
@@ -128,24 +128,24 @@ value class ReactiveState<out T>(val raw: T) {
     }
 }
 @InternalReactiveApi
-data class InternalReactiveWrapper<T>(val other: T)
+public data class InternalReactiveWrapper<T>(val other: T)
 @InternalReactiveApi
-data class InternalReactiveThrownException(val exception: Exception)
+public data class InternalReactiveThrownException(val exception: Exception)
 @InternalReactiveApi
-object InternalReactiveNotReady
+public object InternalReactiveNotReady
 @InternalReactiveApi
-object InternalReactiveNotActive
+public object InternalReactiveNotActive
 
-open class NotReadyException(message: String? = null) : IllegalStateException(message)
+public open class NotReadyException(message: String? = null) : IllegalStateException(message)
 
 /**
  * Thrown when reading a value from a reactive that nothing is listening to, and which therefore
  * has no value to give. Subscribe to it first, or use `awaitOnce`, which subscribes for as long
  * as it takes to obtain a value.
  */
-class NotActiveException(message: String = "Nothing is listening to this reactive value, so it has no value to report. Subscribe to it, or use awaitOnce.") : NotReadyException(message)
+public class NotActiveException(message: String = "Nothing is listening to this reactive value, so it has no value to report. Subscribe to it, or use awaitOnce.") : NotReadyException(message)
 
-inline fun <T> reactiveState(action: () -> T): ReactiveState<T> {
+public inline fun <T> reactiveState(action: () -> T): ReactiveState<T> {
     @OptIn(InternalReactiveApi::class)
     return try {
         ReactiveState(action())
@@ -161,7 +161,7 @@ inline fun <T> reactiveState(action: () -> T): ReactiveState<T> {
     }
 }
 
-fun <T> Result<T>.toReactiveState(): ReactiveState<T> {
+public fun <T> Result<T>.toReactiveState(): ReactiveState<T> {
     @Suppress("UNCHECKED_CAST")
     return if(this.isFailure) ReactiveState.exception(this.exceptionOrNull() as Exception)
     else ReactiveState.wrap(this.getOrNull() as T)

--- a/src/commonMain/kotlin/com/lightningkite/reactive/core/Remember.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/core/Remember.kt
@@ -39,7 +39,7 @@ import kotlin.time.Duration
  * b.value = 2 // prints "sum: 3"
  * ```
  */
-fun <T> remember(
+public fun <T> remember(
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
     useLastWhileLoading: Boolean = false,
     deactivationDelay: Duration? = null,
@@ -74,11 +74,11 @@ fun <T> remember(
  * Listeners can be added to be notified when the value changes. The calculation is protected against
  * cancellation exceptions, and any other exceptions are reported via [Reactive.reportException].
  */
-class Remember<T>(
-    val incomingCoroutineContext: CoroutineContext = Dispatchers.Unconfined,
+public class Remember<T>(
+    public val incomingCoroutineContext: CoroutineContext = Dispatchers.Unconfined,
     private val useLastWhileLoading: Boolean = false,
     private val deactivationDelay: Duration? = null,
-    private val reentrancyLimit: Int = 0,
+    reentrancyLimit: Int = 0,
     private val action: ReactiveContext.() -> T,
 ) : Reactive<T>, CoroutineScope, BaseListenable() {
 
@@ -96,7 +96,7 @@ class Remember<T>(
     // and TypedReactiveContext.init's `scope.onRemove { cancel() }` then attaches an
     // invokeOnCompletion handler to the app-lifetime Job that never fires — leaking every
     // Remember/shared reactive graph forever. Matches RememberSuspending's ordering.
-    override val coroutineContext get() = restOfContext + job
+    override val coroutineContext: CoroutineContext get() = restOfContext + job
 
     // Starts notActive rather than notReady: nothing is listening yet, so there is no value to
     // be had, as opposed to one that is on its way.

--- a/src/commonMain/kotlin/com/lightningkite/reactive/core/RememberSuspending.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/core/RememberSuspending.kt
@@ -38,7 +38,7 @@ import kotlin.time.Duration
  *
  * @see [remember]
  */
-fun <T> rememberSuspending(
+public fun <T> rememberSuspending(
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
     useLastWhileLoading: Boolean = false,
     deactivationDelay: Duration? = null,
@@ -72,9 +72,9 @@ fun <T> rememberSuspending(
  *
  * @see [Remember]
  */
-class RememberSuspending<T>(
-    val incomingCoroutineContext: CoroutineContext = Dispatchers.Unconfined,
-    private val useLastWhileLoading: Boolean = false,
+public class RememberSuspending<T>(
+    public val incomingCoroutineContext: CoroutineContext = Dispatchers.Unconfined,
+    useLastWhileLoading: Boolean = false,
     private val deactivationDelay: Duration? = null,
     private val action: suspend ReactiveCoroutineScope.() -> T,
 ) : Reactive<T>, CoroutineScope, BaseListenable() {

--- a/src/commonMain/kotlin/com/lightningkite/reactive/core/abstracts.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/core/abstracts.kt
@@ -22,7 +22,7 @@ import kotlin.coroutines.cancellation.CancellationException
  * }
  * ```
  */
-abstract class BaseListenable : Listenable {
+public abstract class BaseListenable : Listenable {
     /**
      * Called when the first listener is added.
      * Override to start calculations, resource usage, or subscriptions.
@@ -41,7 +41,7 @@ abstract class BaseListenable : Listenable {
      * Number of currently-registered listeners. Exposed for tests that need to assert
      * that a listenable is not leaking subscriptions.
      */
-    val listenerCount: Int get() = listeners.size
+    public val listenerCount: Int get() = listeners.size
 
     override fun addListener(listener: () -> Unit): Release {
         if (listeners.isEmpty()) activate()
@@ -76,7 +76,7 @@ abstract class BaseListenable : Listenable {
  *
  * @see BaseListenable
  */
-abstract class BaseReactive<T>(start: ReactiveState<T> = ReactiveState.notReady) : Reactive<T>, BaseListenable() {
+public abstract class BaseReactive<T>(start: ReactiveState<T> = ReactiveState.notReady) : Reactive<T>, BaseListenable() {
     override var state: ReactiveState<T> = start
         protected set(value) {
             if (field.raw !== value.raw && field != value) {
@@ -95,7 +95,7 @@ abstract class BaseReactive<T>(start: ReactiveState<T> = ReactiveState.notReady)
  *
  * @see BaseListenable
  */
-abstract class BaseReactiveValue<T>(start: T) : ReactiveValue<T>, BaseListenable() {
+public abstract class BaseReactiveValue<T>(start: T) : ReactiveValue<T>, BaseListenable() {
     override var value: T = start
         set(value) {
             @Suppress("SuspiciousEqualsCombination")

--- a/src/commonMain/kotlin/com/lightningkite/reactive/core/coreInterfaces.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/core/coreInterfaces.kt
@@ -28,7 +28,7 @@ import kotlin.reflect.KProperty
  * release() // Safe to call again, no effect
  * ```
  */
-typealias Release = () -> Unit
+public typealias Release = () -> Unit
 
 /**
  * Represents a resource that can be used and released.
@@ -36,11 +36,11 @@ typealias Release = () -> Unit
  *
  * @see Listenable
  */
-interface ResourceUse {
+public interface ResourceUse {
     /**
      * Begins using the resource. Returns a function to stop using the resource.
      */
-    fun beginUse(): Release
+    public fun beginUse(): Release
 }
 
 
@@ -52,16 +52,16 @@ interface ResourceUse {
  *
  * @see ResourceUse
  */
-interface Listenable : ResourceUse {
+public interface Listenable : ResourceUse {
     /**
      * Adds the [listener] to be called every time this event fires.
      * @return a [Release] handle to remove the [listener] that was added. Removing multiple times should not cause issues.
      */
-    fun addListener(listener: () -> Unit): Release
+    public fun addListener(listener: () -> Unit): Release
 
     override fun beginUse(): Release = addListener { }
 
-    object Never: Listenable {
+    public object Never: Listenable {
         public val NOOP_RELEASE: Release = {}
 
         override fun addListener(listener: () -> Unit): Release = NOOP_RELEASE
@@ -72,7 +72,7 @@ interface Listenable : ResourceUse {
  * Adds a listener and immediately runs it once.
  * @return a [Release] handle to remove the listener.
  */
-fun Listenable.addAndRunListener(listener: () -> Unit): Release {
+public fun Listenable.addAndRunListener(listener: () -> Unit): Release {
     val release = addListener(listener)
     listener()
     return release
@@ -91,7 +91,7 @@ fun Listenable.addAndRunListener(listener: () -> Unit): Release {
  * @see ReactiveState
  * @see com.lightningkite.reactive.context.ReactiveContext
  */
-interface Reactive<out T> : Listenable {
+public interface Reactive<out T> : Listenable {
     /**
      * The current state.
      *
@@ -100,26 +100,26 @@ interface Reactive<out T> : Listenable {
      * a value they are no longer keeping up to date. Anything else is a promise that the state is
      * current, which is what lets callers read it without subscribing.
      */
-    val state: ReactiveState<T>
+    public val state: ReactiveState<T>
 
-    object Never: Reactive<Nothing> {
+    public object Never: Reactive<Nothing> {
         override val state: ReactiveState<Nothing> get() = ReactiveState.notReady
         override fun addListener(listener: () -> Unit): Release = Listenable.Never.NOOP_RELEASE
     }
 
-    companion object Companion {
+    public companion object Companion {
         /**
          * Used to report exceptions thrown in listeners or reactive calculations.
          */
-        var reportException: (Throwable) -> Unit = { it.printStackTrace() }
+        public var reportException: (Throwable) -> Unit = { it.printStackTrace() }
     }
 }
 
 /**
  * Represents a mutable value that can be set asynchronously.
  */
-interface Mutable<T> {
-    suspend infix fun set(value: T)
+public interface Mutable<T> {
+    public suspend infix fun set(value: T)
 }
 
 /**
@@ -132,7 +132,7 @@ interface Mutable<T> {
  * @see Reactive
  * @see Mutable
  */
-interface MutableReactive<T> : Reactive<T>, Mutable<T> {
+public interface MutableReactive<T> : Reactive<T>, Mutable<T> {
 
     /**
      * 'Lenses' a new type from this [MutableReactive]. This is useful when translating one
@@ -156,7 +156,7 @@ interface MutableReactive<T> : Reactive<T>, Mutable<T> {
      * )
      * ```
      */
-    fun <L> lens(
+    public fun <L> lens(
         get: (T) -> L,
         set: (L) -> T
     ): MutableReactive<L> = SetLens(this, get, set)
@@ -185,7 +185,7 @@ interface MutableReactive<T> : Reactive<T>, Mutable<T> {
      * )
      * ```
      */
-    fun <L> lens(
+    public fun <L> lens(
         get: (T) -> L,
         modify: (T, L) -> T
     ): MutableReactive<L> = ModifyLens(this, get, modify)
@@ -202,8 +202,8 @@ interface MutableReactive<T> : Reactive<T>, Mutable<T> {
  *
  * @see Reactive
  */
-interface ReactiveValue<out T> : Reactive<T>, ReadOnlyProperty<Any?, T> {
-    val value: T
+public interface ReactiveValue<out T> : Reactive<T>, ReadOnlyProperty<Any?, T> {
+    public val value: T
 
     // A ReactiveValue always has a value, so its state can never be notReady or notActive. That
     // makes it the wrong interface for anything that only maintains a value while listened to.
@@ -219,8 +219,8 @@ interface ReactiveValue<out T> : Reactive<T>, ReadOnlyProperty<Any?, T> {
  *
  * @see Mutable
  */
-interface MutableValue<T>: Mutable<T> {
-    infix fun valueSet(value: T)
+public interface MutableValue<T>: Mutable<T> {
+    public infix fun valueSet(value: T)
     override suspend fun set(value: T) { valueSet(value) }
 }
 
@@ -229,14 +229,14 @@ interface MutableValue<T>: Mutable<T> {
  *
  * Combines [MutableReactive] and [ReactiveValue].
  */
-interface MutableWithReactiveValue<T> : MutableReactive<T>, ReactiveValue<T>
+public interface MutableWithReactiveValue<T> : MutableReactive<T>, ReactiveValue<T>
 
 /**
  * A [Reactive] that can be synchronously modified.
  *
  * Combines [MutableReactive] and [MutableValue].
  */
-interface ReactiveWithMutableValue<T> : MutableReactive<T>, MutableValue<T>
+public interface ReactiveWithMutableValue<T> : MutableReactive<T>, MutableValue<T>
 
 /**
  * Represents a mutable reactive value that can be modified and observed for changes.
@@ -251,7 +251,7 @@ interface ReactiveWithMutableValue<T> : MutableReactive<T>, MutableValue<T>
  * @see MutableWithReactiveValue
  * @see ReactiveWithMutableValue
  */
-interface MutableReactiveValue<T> : MutableValue<T>, ReactiveValue<T>,
+public interface MutableReactiveValue<T> : MutableValue<T>, ReactiveValue<T>,
     // Interfaces below are just for typing convenience, they are already implemented by intersection of MutableSignal and ValueSignal
     MutableReactive<T>,
     MutableWithReactiveValue<T>,

--- a/src/commonMain/kotlin/com/lightningkite/reactive/core/processes.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/core/processes.kt
@@ -7,12 +7,12 @@ import kotlinx.coroutines.launch
 import kotlin.jvm.JvmName
 
 
-interface Emitter<T>: CoroutineScope {
-    fun emit(value: T)
+public interface Emitter<T>: CoroutineScope {
+    public fun emit(value: T)
 }
 
 @JvmName("reactiveProcessImplicit")
-fun <T> CoroutineScope.reactiveProcess(emitter: suspend Emitter<T>.() -> Unit): Reactive<T> {
+public fun <T> CoroutineScope.reactiveProcess(emitter: suspend Emitter<T>.() -> Unit): Reactive<T> {
     val prop = LateInitSignal<T>()
     launch {
         emitter(object : Emitter<T>, CoroutineScope by this {
@@ -25,7 +25,7 @@ fun <T> CoroutineScope.reactiveProcess(emitter: suspend Emitter<T>.() -> Unit): 
 }
 // The two below only run their emitter while something is listening, so with no listeners they
 // report notActive: whatever the emitter last produced is no longer being kept up to date.
-fun <T> reactiveProcess(scope: CoroutineScope = AppScope, emitter: suspend Emitter<T>.() -> Unit): Reactive<T> {
+public fun <T> reactiveProcess(scope: CoroutineScope = AppScope, emitter: suspend Emitter<T>.() -> Unit): Reactive<T> {
     return object: BaseReactive<T>(ReactiveState.notActive) {
         var job: Job? = null
         override fun activate() {
@@ -45,7 +45,7 @@ fun <T> reactiveProcess(scope: CoroutineScope = AppScope, emitter: suspend Emitt
         }
     }
 }
-fun <T> rawReactiveProcess(scope: CoroutineScope = AppScope, emitter: suspend Emitter<ReactiveState<T>>.() -> Unit): Reactive<T> {
+public fun <T> rawReactiveProcess(scope: CoroutineScope = AppScope, emitter: suspend Emitter<ReactiveState<T>>.() -> Unit): Reactive<T> {
     return object: BaseReactive<T>(ReactiveState.notActive) {
         var job: Job? = null
         override fun activate() {

--- a/src/commonMain/kotlin/com/lightningkite/reactive/core/signals.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/core/signals.kt
@@ -8,7 +8,7 @@ import kotlin.jvm.JvmInline
  * A reactive value that exposes its state and allows direct mutation.
  * Used for low-level reactive state management.
  */
-class RawReactive<T>(start: ReactiveState<T> = ReactiveState.notReady) : BaseReactive<T>(start) {
+public class RawReactive<T>(start: ReactiveState<T> = ReactiveState.notReady) : BaseReactive<T>(start) {
     override var state: ReactiveState<T>
         get() = super.state
         public set(value) { super.state = value }
@@ -18,13 +18,13 @@ class RawReactive<T>(start: ReactiveState<T> = ReactiveState.notReady) : BaseRea
  * A basic implementation of a listenable object.
  * Can invoke all listeners and provides a unique identifier for debugging.
  */
-class BasicListenable : BaseListenable() {
+public class BasicListenable : BaseListenable() {
     private var id = Random.nextInt(0, 100000)
     override fun toString(): String {
         return "BasicListenable($id)"
     }
 
-    fun invokeAll() {
+    public fun invokeAll() {
         super.invokeAllListeners()
     }
 }
@@ -47,18 +47,18 @@ class BasicListenable : BaseListenable() {
  * number.value = 2 // prints "Number: 2"
  * ```
  */
-class Signal<T>(startValue: T) : MutableReactiveValue<T>, BaseReactiveValue<T>(startValue)
+public class Signal<T>(startValue: T) : MutableReactiveValue<T>, BaseReactiveValue<T>(startValue)
 
 /**
  * A reactive value that can be set after initialization and unset to a not-ready state.
  * Useful for cases where the value is not available at construction time.
  */
-class LateInitSignal<T>() : ReactiveWithMutableValue<T>, BaseReactive<T>() {
+public class LateInitSignal<T>() : ReactiveWithMutableValue<T>, BaseReactive<T>() {
     override fun valueSet(value: T) {
         state = ReactiveState(value)
     }
 
-    fun unset() {
+    public fun unset() {
         state = ReactiveState.notReady
     }
 }
@@ -71,6 +71,6 @@ class LateInitSignal<T>() : ReactiveWithMutableValue<T>, BaseReactive<T>() {
  * no overhead.
  */
 @JvmInline
-value class Constant<T>(override val value: T) : ReactiveValue<T> {
+public value class Constant<T>(override val value: T) : ReactiveValue<T> {
     override fun addListener(listener: () -> Unit): Release = Listenable.Never.NOOP_RELEASE
 }

--- a/src/commonMain/kotlin/com/lightningkite/reactive/deprecated.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/deprecated.kt
@@ -32,84 +32,84 @@ import kotlin.jvm.JvmName
 
 
 @Deprecated("Only exists to not break imports", level = DeprecationLevel.ERROR)
-fun <T> Nothing.bind(): Nothing = TODO()
+public fun <T> Nothing.bind(): Nothing = TODO()
 
 // Naming deprecations
 
 @Deprecated("Use Reactive", ReplaceWith("Reactive", "com.lightningkite.reactive.core"))
-typealias Readable<T> = Reactive<T>
+public typealias Readable<T> = Reactive<T>
 
 @Deprecated("Use MutableReactive", ReplaceWith("MutableReactive", "com.lightningkite.reactive.core"))
-typealias Writable<T> = MutableReactive<T>
+public typealias Writable<T> = MutableReactive<T>
 
 @Deprecated("Use Remember", ReplaceWith("Remember", "com.lightningkite.reactive.core"))
-typealias SharedReadable<T> = Remember<T>
+public typealias SharedReadable<T> = Remember<T>
 
 @Deprecated("Use ReactiveValue", ReplaceWith("ReactiveValue", "com.lightningkite.reactive.core"))
-typealias ImmediateReadable<T> = ReactiveValue<T>
+public typealias ImmediateReadable<T> = ReactiveValue<T>
 
 @Deprecated("Use MutableReactiveValue", ReplaceWith("MutableReactiveValue", "com.lightningkite.reactive.core"))
-typealias ImmediateWritable<T> = MutableReactiveValue<T>
+public typealias ImmediateWritable<T> = MutableReactiveValue<T>
 
 @Deprecated("Use ReactiveWithMutableValue", ReplaceWith("ReactiveWithMutableValue", "com.lightningkite.reactive.core"))
-typealias ReadableWithImmediateWrite<T> = ReactiveWithMutableValue<T>
+public typealias ReadableWithImmediateWrite<T> = ReactiveWithMutableValue<T>
 
 @Deprecated("Use MutableWithReactiveValue", ReplaceWith("MutableWithReactiveValue", "com.lightningkite.reactive.core"))
-typealias ImmediateReadableWithWrite<T> = MutableWithReactiveValue<T>
+public typealias ImmediateReadableWithWrite<T> = MutableWithReactiveValue<T>
 
 @Deprecated("Use Signal", ReplaceWith("Signal", "com.lightningkite.reactive.core"))
-typealias Property<T> = Signal<T>
+public typealias Property<T> = Signal<T>
 
 @Deprecated("Use MutableRemember", ReplaceWith("MutableRemember", "com.lightningkite.reactive.core"))
-typealias LazyProperty<T> = MutableRemember<T>
+public typealias LazyProperty<T> = MutableRemember<T>
 
 @Deprecated("Use DebounceReactive", ReplaceWith("DebounceReactive", "com.lightningkite.reactive.extensions"))
-typealias DebounceReadable<T> = DebounceReactive<T>
+public typealias DebounceReadable<T> = DebounceReactive<T>
 
 @OptIn(InternalReactiveApi::class)
 @Deprecated("Use InternalSignalWrapper", ReplaceWith("InternalSignalWrapper", "com.lightningkite.reactive.core"))
-typealias InternalReadableWrapper<T> = InternalReactiveWrapper<T>
+public typealias InternalReadableWrapper<T> = InternalReactiveWrapper<T>
 
 @Deprecated("Use RawReactive", ReplaceWith("RawReactive", "com.lightningkite.reactive.core"))
-typealias RawReadable<T> = RawReactive<T>
+public typealias RawReadable<T> = RawReactive<T>
 
 @Deprecated("Use ReactiveState", ReplaceWith("ReactiveState", "com.lightningkite.reactive.core"))
-typealias ReadableState<T> = ReactiveState<T>
+public typealias ReadableState<T> = ReactiveState<T>
 
 @Deprecated("Use SignalEmitter", ReplaceWith("SignalEmitter", "com.lightningkite.reactive.core"))
-typealias ReadableEmitter<T> = Emitter<T>
+public typealias ReadableEmitter<T> = Emitter<T>
 
 @Deprecated("Use MutableValue", ReplaceWith("MutableValue", "com.lightningkite.reactive.core"))
-typealias ImmediateWriteOnly<T> = MutableValue<T>
+public typealias ImmediateWriteOnly<T> = MutableValue<T>
 
 @Deprecated("Use BaseReactiveValue", ReplaceWith("BaseReactiveValue", "com.lightningkite.reactive.core"))
-typealias BaseImmediateReadable<T> = BaseReactiveValue<T>
+public typealias BaseImmediateReadable<T> = BaseReactiveValue<T>
 
 @Deprecated("Use BaseReactive", ReplaceWith("BaseReactive", "com.lightningkite.reactive.core"))
-typealias BaseReadable<T> = BaseReactive<T>
+public typealias BaseReadable<T> = BaseReactive<T>
 
 @Deprecated("Use BaseReactive", ReplaceWith("BaseReactive", "com.lightningkite.reactive.core"))
-typealias BaseWritable<T> = BaseReactive<T>
+public typealias BaseWritable<T> = BaseReactive<T>
 
 @Deprecated("Use BaseReactiveValue", ReplaceWith("BaseReactiveValue", "com.lightningkite.reactive.core"))
-typealias BaseReadWrite<T> = BaseReactiveValue<T>
+public typealias BaseReadWrite<T> = BaseReactiveValue<T>
 
 @Deprecated("Use LateInitReactiveValue", ReplaceWith("LateInitReactiveValue", "com.lightningkite.reactive.core"))
-typealias LateInitProperty<T> = LateInitSignal<T>
+public typealias LateInitProperty<T> = LateInitSignal<T>
 
 @Deprecated("Use remember", ReplaceWith("remember", "com.lightningkite.reactive.core"))
-fun <T> shared(coroutineContext: CoroutineContext = Dispatchers.Unconfined, useLastWhileLoading: Boolean = false, action: ReactiveContext.() -> T): Reactive<T> =
+public fun <T> shared(coroutineContext: CoroutineContext = Dispatchers.Unconfined, useLastWhileLoading: Boolean = false, action: ReactiveContext.() -> T): Reactive<T> =
     remember(coroutineContext, useLastWhileLoading, null, action = action)
 
 @Deprecated("Use reactiveProcess", ReplaceWith("reactiveProcess", "com.lightningkite.reactive.core"))
-fun <T> sharedProcess(scope: CoroutineScope = AppScope, emitter: suspend Emitter<T>.() -> Unit): Reactive<T> = reactiveProcess(scope, emitter)
+public fun <T> sharedProcess(scope: CoroutineScope = AppScope, emitter: suspend Emitter<T>.() -> Unit): Reactive<T> = reactiveProcess(scope, emitter)
 
 @Deprecated("Use reactiveProcess", ReplaceWith("reactiveProcess", "com.lightningkite.reactive.core"))
 @JvmName("sharedProcessReceiving")
-fun <T> CoroutineScope.sharedProcess(emitter: suspend Emitter<T>.() -> Unit): Reactive<T> = reactiveProcess(emitter)
+public fun <T> CoroutineScope.sharedProcess(emitter: suspend Emitter<T>.() -> Unit): Reactive<T> = reactiveProcess(emitter)
 
 @Deprecated("Use reactiveState", ReplaceWith("reactiveState", "com.lightningkite.reactive.core"))
-inline fun <T> readableState(action: () -> T): ReactiveState<T> = reactiveState(action)
+public inline fun <T> readableState(action: () -> T): ReactiveState<T> = reactiveState(action)
 
 @Deprecated("Use toReactiveState", ReplaceWith("toReactiveState", "com.lightningkite.reactive.core"))
-fun <T> Result<T>.toReadableState(): ReactiveState<T> = toReactiveState()
+public fun <T> Result<T>.toReadableState(): ReactiveState<T> = toReactiveState()

--- a/src/commonMain/kotlin/com/lightningkite/reactive/extensions/Listenable.ext.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/extensions/Listenable.ext.kt
@@ -6,22 +6,22 @@ import com.lightningkite.reactive.core.Reactive
 import com.lightningkite.reactive.core.ReactiveState
 import com.lightningkite.reactive.core.ReactiveValue
 
-inline fun <T> Reactive<T>.addStateListener(crossinline listener: (ReactiveState<T>) -> Unit): Release {
+public inline fun <T> Reactive<T>.addStateListener(crossinline listener: (ReactiveState<T>) -> Unit): Release {
     return addListener { listener(state) }
 }
 
-inline fun <T> Reactive<T>.addAndRunStateListener(crossinline listener: (ReactiveState<T>) -> Unit): Release {
+public inline fun <T> Reactive<T>.addAndRunStateListener(crossinline listener: (ReactiveState<T>) -> Unit): Release {
     val listener: () -> Unit = { listener(state) }
     val release = addListener(listener)
     listener()
     return release
 }
 
-inline fun <T> ReactiveValue<T>.addValueListener(crossinline listener: (T) -> Unit): Release {
+public inline fun <T> ReactiveValue<T>.addValueListener(crossinline listener: (T) -> Unit): Release {
     return addListener { listener(value) }
 }
 
-inline fun <T> ReactiveValue<T>.addAndRunValueListener(crossinline listener: (T) -> Unit): Release {
+public inline fun <T> ReactiveValue<T>.addAndRunValueListener(crossinline listener: (T) -> Unit): Release {
     val listener: () -> Unit = { listener(value) }
     val release = addListener(listener)
     listener()

--- a/src/commonMain/kotlin/com/lightningkite/reactive/extensions/ReactiveState.ext.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/extensions/ReactiveState.ext.kt
@@ -2,7 +2,7 @@ package com.lightningkite.reactive.extensions
 
 import com.lightningkite.reactive.core.ReactiveState
 
-inline fun <R, T : R> ReactiveState<T>.getOrElse(default: () -> R): R {
+public inline fun <R, T : R> ReactiveState<T>.getOrElse(default: () -> R): R {
     return handle(
         success = { it },
         exception = { default() },

--- a/src/commonMain/kotlin/com/lightningkite/reactive/extensions/WaitForNotNull.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/extensions/WaitForNotNull.kt
@@ -22,14 +22,14 @@ internal class WaitForNotNull<T : Any>(val wraps: Reactive<T?>) : Reactive<T> {
 
     override fun equals(other: Any?): Boolean = other is WaitForNotNull<*> && this.wraps == other.wraps
 }
-val <T : Any> Reactive<T?>.waitForNotNull: Reactive<T> get() = WaitForNotNull(this)
+public val <T : Any> Reactive<T?>.waitForNotNull: Reactive<T> get() = WaitForNotNull(this)
 
-val <T : Any> MutableReactive<T?>.waitForNotNull: MutableReactive<T> get() =
+public val <T : Any> MutableReactive<T?>.waitForNotNull: MutableReactive<T> get() =
     object : MutableReactive<T>, Reactive<T> by (this as Reactive<T?>).waitForNotNull { // DO NOT REMOVE THE TYPECAST
         override suspend fun set(value: T) = this@waitForNotNull.set(value)
     }
 
-suspend fun <T : Any> Reactive<T?>.awaitNotNull(): T {
+public suspend fun <T : Any> Reactive<T?>.awaitNotNull(): T {
     val basis = await()
     return basis ?: suspendCancellableCoroutine<T> {  }
 }

--- a/src/commonMain/kotlin/com/lightningkite/reactive/extensions/commaString.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/extensions/commaString.kt
@@ -4,7 +4,7 @@ import kotlin.math.pow
 import kotlin.math.roundToInt
 
 
-fun Double.toStringNoExponential(): String {
+public fun Double.toStringNoExponential(): String {
     val preDecimal = toLong().toString()
     val r = rem(1)
     if (r == 0.0) return preDecimal
@@ -14,15 +14,15 @@ fun Double.toStringNoExponential(): String {
     else return preDecimal + "." + postDecimal.toString().padStart(availableDigits, '0').trimEnd('0')
 }
 
-fun Double.commaString(): String {
+public fun Double.commaString(): String {
     val clean = this.toStringNoExponential().filter { it.isDigit() || it in setOf('.', '-') }
     val preDecimal = clean.substringBefore('.').reversed().chunked(3) { it.reversed() }.reversed().joinToString(",")
     val postDecimal = clean.substringAfter('.', "")
     return if (clean.contains('.')) "$preDecimal.$postDecimal" else preDecimal
 }
-fun Int.commaString(): String {
+public fun Int.commaString(): String {
     return toString().substringBefore('.').reversed().chunked(3) { it.reversed() }.reversed().joinToString(",")
 }
-fun Long.commaString(): String {
+public fun Long.commaString(): String {
     return toString().substringBefore('.').reversed().chunked(3) { it.reversed() }.reversed().joinToString(",")
 }

--- a/src/commonMain/kotlin/com/lightningkite/reactive/extensions/commonLenses.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/extensions/commonLenses.kt
@@ -9,78 +9,78 @@ import com.lightningkite.reactive.lensing.validation.MutableValidatedValue
 import kotlin.collections.plus
 import kotlin.jvm.JvmName
 
-infix fun <T> MutableReactive<T>.equalTo(value: T): MutableReactive<Boolean> = lens(
+public infix fun <T> MutableReactive<T>.equalTo(value: T): MutableReactive<Boolean> = lens(
     get = { it == value },
     modify = { o, it -> if (it) value else o }
 )
 
-fun <T : Any> MutableReactive<T?>.notNull(default: T): MutableReactive<T> = lens(
+public fun <T : Any> MutableReactive<T?>.notNull(default: T): MutableReactive<T> = lens(
     get = { it ?: default },
     set = { it }
 )
 
-fun MutableReactive<String?>.nullToBlank(): MutableReactive<String> = lens(
+public fun MutableReactive<String?>.nullToBlank(): MutableReactive<String> = lens(
     get = { it ?: "" },
     set = { it.takeUnless { it.isBlank() } }
 )
 
-infix fun <T> MutableReactive<Set<T>>.contains(value: T): MutableReactive<Boolean> = lens(
+public infix fun <T> MutableReactive<Set<T>>.contains(value: T): MutableReactive<Boolean> = lens(
     get = { value in it },
     modify = { items, bool -> if (bool) items + value else items - value  }
 )
 
 @JvmName("containsList")
-infix fun <T> MutableReactive<List<T>>.contains(value: T): MutableReactive<Boolean> = lens(
+public infix fun <T> MutableReactive<List<T>>.contains(value: T): MutableReactive<Boolean> = lens(
     get = { value in it },
     modify = { items, bool -> if (bool) items + value else items - value }
 )
 
 @JvmName("writableStringAsDouble")
-fun MutableReactive<String>.asDouble(): MutableReactive<Double?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toDoubleOrNull() }, set = { it?.commaString() ?: "" })
+public fun MutableReactive<String>.asDouble(): MutableReactive<Double?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toDoubleOrNull() }, set = { it?.commaString() ?: "" })
 
 @JvmName("writableStringAsFloat")
-fun MutableReactive<String>.asFloat(): MutableReactive<Float?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toFloatOrNull() }, set = { it?.toDouble()?.commaString() ?: "" })
+public fun MutableReactive<String>.asFloat(): MutableReactive<Float?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toFloatOrNull() }, set = { it?.toDouble()?.commaString() ?: "" })
 
 @JvmName("writableStringAsByte")
-fun MutableReactive<String>.asByte(): MutableReactive<Byte?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toByteOrNull() }, set = { it?.toInt()?.commaString() ?: "" })
+public fun MutableReactive<String>.asByte(): MutableReactive<Byte?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toByteOrNull() }, set = { it?.toInt()?.commaString() ?: "" })
 
 @JvmName("writableStringAsShort")
-fun MutableReactive<String>.asShort(): MutableReactive<Short?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toShortOrNull() }, set = { it?.toInt()?.commaString() ?: "" })
+public fun MutableReactive<String>.asShort(): MutableReactive<Short?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toShortOrNull() }, set = { it?.toInt()?.commaString() ?: "" })
 
 @JvmName("writableStringAsInt")
-fun MutableReactive<String>.asInt(): MutableReactive<Int?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toIntOrNull() }, set = { it?.commaString() ?: "" })
+public fun MutableReactive<String>.asInt(): MutableReactive<Int?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toIntOrNull() }, set = { it?.commaString() ?: "" })
 
 @JvmName("writableStringAsLong")
-fun MutableReactive<String>.asLong(): MutableReactive<Long?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toLongOrNull() }, set = { it?.commaString() ?: "" })
+public fun MutableReactive<String>.asLong(): MutableReactive<Long?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toLongOrNull() }, set = { it?.commaString() ?: "" })
 
 @JvmName("writableStringAsByteHex")
-fun MutableReactive<String>.asByteHex(): MutableReactive<Byte?> = lens(get = { it.toByteOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableReactive<String>.asByteHex(): MutableReactive<Byte?> = lens(get = { it.toByteOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsUByteHex")
-fun MutableReactive<String>.asUByteHex(): MutableReactive<UByte?> = lens(get = { it.toUByteOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableReactive<String>.asUByteHex(): MutableReactive<UByte?> = lens(get = { it.toUByteOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsShortHex")
-fun MutableReactive<String>.asShortHex(): MutableReactive<Short?> = lens(get = { it.toShortOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableReactive<String>.asShortHex(): MutableReactive<Short?> = lens(get = { it.toShortOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsUShortHex")
-fun MutableReactive<String>.asUShortHex(): MutableReactive<UShort?> = lens(get = { it.toUShortOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableReactive<String>.asUShortHex(): MutableReactive<UShort?> = lens(get = { it.toUShortOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsIntHex")
-fun MutableReactive<String>.asIntHex(): MutableReactive<Int?> = lens(get = { it.toIntOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableReactive<String>.asIntHex(): MutableReactive<Int?> = lens(get = { it.toIntOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsUIntHex")
-fun MutableReactive<String>.asUIntHex(): MutableReactive<UInt?> = lens(get = { it.toUIntOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableReactive<String>.asUIntHex(): MutableReactive<UInt?> = lens(get = { it.toUIntOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsLongHex")
-fun MutableReactive<String>.asLongHex(): MutableReactive<Long?> = lens(get = { it.toLongOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableReactive<String>.asLongHex(): MutableReactive<Long?> = lens(get = { it.toLongOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsULongHex")
-fun MutableReactive<String>.asULongHex(): MutableReactive<ULong?> = lens(get = { it.toULongOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableReactive<String>.asULongHex(): MutableReactive<ULong?> = lens(get = { it.toULongOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableIntAsDoubleNullable")
-fun MutableReactive<Int?>.asDouble(): MutableReactive<Double?> = lens(get = { it?.toDouble() }, set = { it?.toInt() })
+public fun MutableReactive<Int?>.asDouble(): MutableReactive<Double?> = lens(get = { it?.toDouble() }, set = { it?.toInt() })
 
-fun MutableReactive<Double>.nullToZero(): MutableReactive<Double?> =
+public fun MutableReactive<Double>.nullToZero(): MutableReactive<Double?> =
     object : MutableReactive<Double?>, Reactive<Double?> by this {
         override suspend fun set(value: Double?) {
             this@nullToZero.set(value ?: 0.0)
@@ -88,144 +88,144 @@ fun MutableReactive<Double>.nullToZero(): MutableReactive<Double?> =
     }
 
 @JvmName("writableStringAsDouble")
-fun MutableReactiveValue<String>.asDouble(): MutableReactiveValue<Double?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toDoubleOrNull() }, set = { it?.commaString() ?: "" })
+public fun MutableReactiveValue<String>.asDouble(): MutableReactiveValue<Double?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toDoubleOrNull() }, set = { it?.commaString() ?: "" })
 
 @JvmName("writableStringAsFloat")
-fun MutableReactiveValue<String>.asFloat(): MutableReactiveValue<Float?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toFloatOrNull() }, set = { it?.toDouble()?.commaString() ?: "" })
+public fun MutableReactiveValue<String>.asFloat(): MutableReactiveValue<Float?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toFloatOrNull() }, set = { it?.toDouble()?.commaString() ?: "" })
 
 @JvmName("writableStringAsByte")
-fun MutableReactiveValue<String>.asByte(): MutableReactiveValue<Byte?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toByteOrNull() }, set = { it?.toInt()?.commaString() ?: "" })
+public fun MutableReactiveValue<String>.asByte(): MutableReactiveValue<Byte?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toByteOrNull() }, set = { it?.toInt()?.commaString() ?: "" })
 
 @JvmName("writableStringAsShort")
-fun MutableReactiveValue<String>.asShort(): MutableReactiveValue<Short?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toShortOrNull() }, set = { it?.toInt()?.commaString() ?: "" })
+public fun MutableReactiveValue<String>.asShort(): MutableReactiveValue<Short?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toShortOrNull() }, set = { it?.toInt()?.commaString() ?: "" })
 
 @JvmName("writableStringAsInt")
-fun MutableReactiveValue<String>.asInt(): MutableReactiveValue<Int?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toIntOrNull() }, set = { it?.commaString() ?: "" })
+public fun MutableReactiveValue<String>.asInt(): MutableReactiveValue<Int?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toIntOrNull() }, set = { it?.commaString() ?: "" })
 
 @JvmName("writableStringAsLong")
-fun MutableReactiveValue<String>.asLong(): MutableReactiveValue<Long?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toLongOrNull() }, set = { it?.commaString() ?: "" })
+public fun MutableReactiveValue<String>.asLong(): MutableReactiveValue<Long?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toLongOrNull() }, set = { it?.commaString() ?: "" })
 
 @JvmName("writableStringAsByteHex")
-fun MutableReactiveValue<String>.asByteHex(): MutableReactiveValue<Byte?> = lens(get = { it.toByteOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableReactiveValue<String>.asByteHex(): MutableReactiveValue<Byte?> = lens(get = { it.toByteOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsUByteHex")
-fun MutableReactiveValue<String>.asUByteHex(): MutableReactiveValue<UByte?> = lens(get = { it.toUByteOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableReactiveValue<String>.asUByteHex(): MutableReactiveValue<UByte?> = lens(get = { it.toUByteOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsShortHex")
-fun MutableReactiveValue<String>.asShortHex(): MutableReactiveValue<Short?> = lens(get = { it.toShortOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableReactiveValue<String>.asShortHex(): MutableReactiveValue<Short?> = lens(get = { it.toShortOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsUShortHex")
-fun MutableReactiveValue<String>.asUShortHex(): MutableReactiveValue<UShort?> = lens(get = { it.toUShortOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableReactiveValue<String>.asUShortHex(): MutableReactiveValue<UShort?> = lens(get = { it.toUShortOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsIntHex")
-fun MutableReactiveValue<String>.asIntHex(): MutableReactiveValue<Int?> = lens(get = { it.toIntOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableReactiveValue<String>.asIntHex(): MutableReactiveValue<Int?> = lens(get = { it.toIntOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsUIntHex")
-fun MutableReactiveValue<String>.asUIntHex(): MutableReactiveValue<UInt?> = lens(get = { it.toUIntOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableReactiveValue<String>.asUIntHex(): MutableReactiveValue<UInt?> = lens(get = { it.toUIntOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsLongHex")
-fun MutableReactiveValue<String>.asLongHex(): MutableReactiveValue<Long?> = lens(get = { it.toLongOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableReactiveValue<String>.asLongHex(): MutableReactiveValue<Long?> = lens(get = { it.toLongOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsULongHex")
-fun MutableReactiveValue<String>.asULongHex(): MutableReactiveValue<ULong?> = lens(get = { it.toULongOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableReactiveValue<String>.asULongHex(): MutableReactiveValue<ULong?> = lens(get = { it.toULongOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableIntAsDoubleNullable")
-fun MutableReactiveValue<Int?>.asDouble(): MutableReactiveValue<Double?> = lens(get = { it?.toDouble() }, set = { it?.toInt() })
+public fun MutableReactiveValue<Int?>.asDouble(): MutableReactiveValue<Double?> = lens(get = { it?.toDouble() }, set = { it?.toInt() })
 
 // Validated variants
 
 
-fun MutableValidated<String?>.nullToBlank(): MutableValidated<String> = lens(
+public fun MutableValidated<String?>.nullToBlank(): MutableValidated<String> = lens(
     get = { it ?: "" },
     set = { it.takeUnless { it.isBlank() } }
 )
 
 @JvmName("writableStringAsDoubleValidated")
-fun MutableValidated<String>.asDouble(): MutableValidated<Double?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toDoubleOrNull() }, set = { it?.commaString() ?: "" })
+public fun MutableValidated<String>.asDouble(): MutableValidated<Double?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toDoubleOrNull() }, set = { it?.commaString() ?: "" })
 
 @JvmName("writableStringAsFloatValidated")
-fun MutableValidated<String>.asFloat(): MutableValidated<Float?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toFloatOrNull() }, set = { it?.toDouble()?.commaString() ?: "" })
+public fun MutableValidated<String>.asFloat(): MutableValidated<Float?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toFloatOrNull() }, set = { it?.toDouble()?.commaString() ?: "" })
 
 @JvmName("writableStringAsByteValidated")
-fun MutableValidated<String>.asByte(): MutableValidated<Byte?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toByteOrNull() }, set = { it?.toInt()?.commaString() ?: "" })
+public fun MutableValidated<String>.asByte(): MutableValidated<Byte?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toByteOrNull() }, set = { it?.toInt()?.commaString() ?: "" })
 
 @JvmName("writableStringAsShortValidated")
-fun MutableValidated<String>.asShort(): MutableValidated<Short?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toShortOrNull() }, set = { it?.toInt()?.commaString() ?: "" })
+public fun MutableValidated<String>.asShort(): MutableValidated<Short?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toShortOrNull() }, set = { it?.toInt()?.commaString() ?: "" })
 
 @JvmName("writableStringAsIntValidated")
-fun MutableValidated<String>.asInt(): MutableValidated<Int?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toIntOrNull() }, set = { it?.commaString() ?: "" })
+public fun MutableValidated<String>.asInt(): MutableValidated<Int?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toIntOrNull() }, set = { it?.commaString() ?: "" })
 
 @JvmName("writableStringAsLongValidated")
-fun MutableValidated<String>.asLong(): MutableValidated<Long?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toLongOrNull() }, set = { it?.commaString() ?: "" })
+public fun MutableValidated<String>.asLong(): MutableValidated<Long?> = lens(get = { it.filter { it.isDigit() || it == '.' }.toLongOrNull() }, set = { it?.commaString() ?: "" })
 
 @JvmName("writableStringAsByteHexValidated")
-fun MutableValidated<String>.asByteHex(): MutableValidated<Byte?> = lens(get = { it.toByteOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableValidated<String>.asByteHex(): MutableValidated<Byte?> = lens(get = { it.toByteOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsUByteHexValidated")
-fun MutableValidated<String>.asUByteHex(): MutableValidated<UByte?> = lens(get = { it.toUByteOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableValidated<String>.asUByteHex(): MutableValidated<UByte?> = lens(get = { it.toUByteOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsShortHexValidated")
-fun MutableValidated<String>.asShortHex(): MutableValidated<Short?> = lens(get = { it.toShortOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableValidated<String>.asShortHex(): MutableValidated<Short?> = lens(get = { it.toShortOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsUShortHexValidated")
-fun MutableValidated<String>.asUShortHex(): MutableValidated<UShort?> = lens(get = { it.toUShortOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableValidated<String>.asUShortHex(): MutableValidated<UShort?> = lens(get = { it.toUShortOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsIntHexValidated")
-fun MutableValidated<String>.asIntHex(): MutableValidated<Int?> = lens(get = { it.toIntOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableValidated<String>.asIntHex(): MutableValidated<Int?> = lens(get = { it.toIntOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsUIntHexValidated")
-fun MutableValidated<String>.asUIntHex(): MutableValidated<UInt?> = lens(get = { it.toUIntOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableValidated<String>.asUIntHex(): MutableValidated<UInt?> = lens(get = { it.toUIntOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsLongHexValidated")
-fun MutableValidated<String>.asLongHex(): MutableValidated<Long?> = lens(get = { it.toLongOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableValidated<String>.asLongHex(): MutableValidated<Long?> = lens(get = { it.toLongOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsULongHexValidated")
-fun MutableValidated<String>.asULongHex(): MutableValidated<ULong?> = lens(get = { it.toULongOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableValidated<String>.asULongHex(): MutableValidated<ULong?> = lens(get = { it.toULongOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableIntAsDoubleNullableValidated")
-fun MutableValidated<Int?>.asDouble(): MutableValidated<Double?> = lens(get = { it?.toDouble() }, set = { it?.toInt() })
+public fun MutableValidated<Int?>.asDouble(): MutableValidated<Double?> = lens(get = { it?.toDouble() }, set = { it?.toInt() })
 
 @JvmName("writableStringAsDoubleValidatedValue")
-fun MutableValidatedValue<String>.asDouble(): MutableValidatedValue<Double?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toDoubleOrNull() }, set = { it?.commaString() ?: "" })
+public fun MutableValidatedValue<String>.asDouble(): MutableValidatedValue<Double?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toDoubleOrNull() }, set = { it?.commaString() ?: "" })
 
 @JvmName("writableStringAsFloatValidatedValue")
-fun MutableValidatedValue<String>.asFloat(): MutableValidatedValue<Float?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toFloatOrNull() }, set = { it?.toDouble()?.commaString() ?: "" })
+public fun MutableValidatedValue<String>.asFloat(): MutableValidatedValue<Float?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toFloatOrNull() }, set = { it?.toDouble()?.commaString() ?: "" })
 
 @JvmName("writableStringAsByteValidatedValue")
-fun MutableValidatedValue<String>.asByte(): MutableValidatedValue<Byte?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toByteOrNull() }, set = { it?.toInt()?.commaString() ?: "" })
+public fun MutableValidatedValue<String>.asByte(): MutableValidatedValue<Byte?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toByteOrNull() }, set = { it?.toInt()?.commaString() ?: "" })
 
 @JvmName("writableStringAsShortValidatedValue")
-fun MutableValidatedValue<String>.asShort(): MutableValidatedValue<Short?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toShortOrNull() }, set = { it?.toInt()?.commaString() ?: "" })
+public fun MutableValidatedValue<String>.asShort(): MutableValidatedValue<Short?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toShortOrNull() }, set = { it?.toInt()?.commaString() ?: "" })
 
 @JvmName("writableStringAsIntValidatedValue")
-fun MutableValidatedValue<String>.asInt(): MutableValidatedValue<Int?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toIntOrNull() }, set = { it?.commaString() ?: "" })
+public fun MutableValidatedValue<String>.asInt(): MutableValidatedValue<Int?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toIntOrNull() }, set = { it?.commaString() ?: "" })
 
 @JvmName("writableStringAsLongValidatedValue")
-fun MutableValidatedValue<String>.asLong(): MutableValidatedValue<Long?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toLongOrNull() }, set = { it?.commaString() ?: "" })
+public fun MutableValidatedValue<String>.asLong(): MutableValidatedValue<Long?> = lens(get = { it.filter { it.isDigit() || it == '-' || it == '.'}.toLongOrNull() }, set = { it?.commaString() ?: "" })
 
 @JvmName("writableStringAsByteHexValidatedValue")
-fun MutableValidatedValue<String>.asByteHex(): MutableValidatedValue<Byte?> = lens(get = { it.toByteOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableValidatedValue<String>.asByteHex(): MutableValidatedValue<Byte?> = lens(get = { it.toByteOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsUByteHexValidatedValue")
-fun MutableValidatedValue<String>.asUByteHex(): MutableValidatedValue<UByte?> = lens(get = { it.toUByteOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableValidatedValue<String>.asUByteHex(): MutableValidatedValue<UByte?> = lens(get = { it.toUByteOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsShortHexValidatedValue")
-fun MutableValidatedValue<String>.asShortHex(): MutableValidatedValue<Short?> = lens(get = { it.toShortOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableValidatedValue<String>.asShortHex(): MutableValidatedValue<Short?> = lens(get = { it.toShortOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsUShortHexValidatedValue")
-fun MutableValidatedValue<String>.asUShortHex(): MutableValidatedValue<UShort?> = lens(get = { it.toUShortOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableValidatedValue<String>.asUShortHex(): MutableValidatedValue<UShort?> = lens(get = { it.toUShortOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsIntHexValidatedValue")
-fun MutableValidatedValue<String>.asIntHex(): MutableValidatedValue<Int?> = lens(get = { it.toIntOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableValidatedValue<String>.asIntHex(): MutableValidatedValue<Int?> = lens(get = { it.toIntOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsUIntHexValidatedValue")
-fun MutableValidatedValue<String>.asUIntHex(): MutableValidatedValue<UInt?> = lens(get = { it.toUIntOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableValidatedValue<String>.asUIntHex(): MutableValidatedValue<UInt?> = lens(get = { it.toUIntOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsLongHexValidatedValue")
-fun MutableValidatedValue<String>.asLongHex(): MutableValidatedValue<Long?> = lens(get = { it.toLongOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableValidatedValue<String>.asLongHex(): MutableValidatedValue<Long?> = lens(get = { it.toLongOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableStringAsULongHexValidatedValue")
-fun MutableValidatedValue<String>.asULongHex(): MutableValidatedValue<ULong?> = lens(get = { it.toULongOrNull(16) }, set = { it?.toString(16) ?: "" })
+public fun MutableValidatedValue<String>.asULongHex(): MutableValidatedValue<ULong?> = lens(get = { it.toULongOrNull(16) }, set = { it?.toString(16) ?: "" })
 
 @JvmName("writableIntAsDoubleNullableValidatedValue")
-fun MutableValidatedValue<Int?>.asDouble(): MutableValidatedValue<Double?> = lens(get = { it?.toDouble() }, set = { it?.toInt() })
+public fun MutableValidatedValue<Int?>.asDouble(): MutableValidatedValue<Double?> = lens(get = { it?.toDouble() }, set = { it?.toInt() })

--- a/src/commonMain/kotlin/com/lightningkite/reactive/extensions/debounce.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/extensions/debounce.kt
@@ -32,10 +32,10 @@ import kotlin.time.Duration.Companion.milliseconds
  *
  * @see DebounceListenable
  */
-class DebounceReactive<T>(
-    val source: Reactive<T>,
-    val scope: CoroutineScope,
-    val duration: Duration
+public class DebounceReactive<T>(
+    public val source: Reactive<T>,
+    public val scope: CoroutineScope,
+    public val duration: Duration
 ) : Reactive<T>, Listenable by DebounceListenable(source, scope, duration) {
     override val state: ReactiveState<T> get() = source.state
 }
@@ -60,7 +60,7 @@ class DebounceReactive<T>(
  *
  * @see DebounceReactive
  */
-class DebounceListenable(val source: Listenable, val scope: CoroutineScope, val duration: Duration) : BaseListenable() {
+public class DebounceListenable(public val source: Listenable, public val scope: CoroutineScope, public val duration: Duration) : BaseListenable() {
     @Volatile
     private var changeCount = 0
 
@@ -87,25 +87,25 @@ class DebounceListenable(val source: Listenable, val scope: CoroutineScope, val 
  * Debounces listener notifications by [timeMs] milliseconds. State is always current.
  * @see DebounceReactive
  */
-fun <T> Reactive<T>.debounce(timeMs: Long, scope: CoroutineScope): Reactive<T> = DebounceReactive(this, scope, timeMs.milliseconds)
+public fun <T> Reactive<T>.debounce(timeMs: Long, scope: CoroutineScope): Reactive<T> = DebounceReactive(this, scope, timeMs.milliseconds)
 
 /**
  * Debounces listener notifications by [duration]. State is always current.
  * @see DebounceReactive
  */
-fun <T> Reactive<T>.debounce(duration: Duration, scope: CoroutineScope): Reactive<T> = DebounceReactive(this, scope, duration)
+public fun <T> Reactive<T>.debounce(duration: Duration, scope: CoroutineScope): Reactive<T> = DebounceReactive(this, scope, duration)
 
 /**
  * Debounces listener notifications by [timeMs] milliseconds.
  * @see DebounceListenable
  */
-fun Listenable.debounce(timeMs: Long, scope: CoroutineScope): Listenable = DebounceListenable(this, scope, timeMs.milliseconds)
+public fun Listenable.debounce(timeMs: Long, scope: CoroutineScope): Listenable = DebounceListenable(this, scope, timeMs.milliseconds)
 
 /**
  * Debounces listener notifications by [duration].
  * @see DebounceListenable
  */
-fun Listenable.debounce(duration: Duration, scope: CoroutineScope): Listenable = DebounceListenable(this, scope, duration)
+public fun Listenable.debounce(duration: Duration, scope: CoroutineScope): Listenable = DebounceListenable(this, scope, duration)
 
 /**
  * Debounces write operations to this [MutableReactive].
@@ -119,7 +119,7 @@ fun Listenable.debounce(duration: Duration, scope: CoroutineScope): Listenable =
  * @param duration The debounce delay for write operations.
  * @return A [MutableReactive] wrapper with debounced writes.
  */
-fun <T> MutableReactive<T>.debounceWrite(duration: Duration): MutableReactive<T> = object: MutableReactive<T> by this {
+public fun <T> MutableReactive<T>.debounceWrite(duration: Duration): MutableReactive<T> = object: MutableReactive<T> by this {
     @Volatile
     var setIndex = 0
 

--- a/src/commonMain/kotlin/com/lightningkite/reactive/extensions/helpers.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/extensions/helpers.kt
@@ -24,8 +24,8 @@ import kotlin.jvm.JvmName
 
 @JsName("invokeAllSafeMutable")
 @JvmName("invokeAllSafeMutable")
-fun MutableList<() -> Unit>.invokeAllSafe() = toList().invokeAllSafe()
-fun List<() -> Unit>.invokeAllSafe() = forEach {
+public fun MutableList<() -> Unit>.invokeAllSafe(): Unit = toList().invokeAllSafe()
+public fun List<() -> Unit>.invokeAllSafe(): Unit = forEach {
     try {
         it()
     } catch (e: Exception) {
@@ -34,7 +34,7 @@ fun List<() -> Unit>.invokeAllSafe() = forEach {
     }
 }
 
-var <T> MutableValue<T>.value: T
+public var <T> MutableValue<T>.value: T
     @Deprecated("This is syntax sugar for SETTING values. Retrieving will always throw an exception.", level = DeprecationLevel.ERROR)
     get() = throw IllegalStateException("Attempted to retrieve value for set-only property")
     @JvmName("setValue2")
@@ -42,7 +42,7 @@ var <T> MutableValue<T>.value: T
         valueSet(value)
     }
 
-operator fun Listenable.plus(other: Listenable): Listenable = object: Listenable {
+public operator fun Listenable.plus(other: Listenable): Listenable = object: Listenable {
     override fun addListener(listener: () -> Unit): Release {
         val a = this@plus.addListener(listener)
         val b = other.addListener(listener)
@@ -53,14 +53,14 @@ operator fun Listenable.plus(other: Listenable): Listenable = object: Listenable
     }
 }
 
-fun <T> Reactive<T>.withWrite(action: suspend Reactive<T>.(T) -> Unit): MutableReactive<T> =
+public fun <T> Reactive<T>.withWrite(action: suspend Reactive<T>.(T) -> Unit): MutableReactive<T> =
     object : MutableReactive<T>, Reactive<T> by this {
         override suspend fun set(value: T) {
             action(this@withWrite, value)
         }
     }
 
-fun <T> Reactive<T>.onNextSuccess(action: (T) -> Unit): Release? {
+public fun <T> Reactive<T>.onNextSuccess(action: (T) -> Unit): Release? {
     // A successful state is one somebody is maintaining, so it needs no subscription at all.
     if (state.success) {
         state.onSuccess(action)
@@ -82,28 +82,28 @@ fun <T> Reactive<T>.onNextSuccess(action: (T) -> Unit): Release? {
     return release
 }
 
-fun <T : Any> MutableReactive<T>.nullable(): MutableReactive<T?> =
+public fun <T : Any> MutableReactive<T>.nullable(): MutableReactive<T?> =
     object : MutableReactive<T?>, Reactive<T?> by this {
         override suspend fun set(value: T?) {
             if (value != null) this@nullable.set(value)
         }
     }
 
-suspend infix fun <T> MutableReactive<T>.modify(action: suspend (T) -> T) {
+public suspend infix fun <T> MutableReactive<T>.modify(action: suspend (T) -> T) {
     set(action(await()))
 }
 
-suspend infix fun <T> MutableReactiveValue<T>.modify(action: suspend (T) -> T) {
+public suspend infix fun <T> MutableReactiveValue<T>.modify(action: suspend (T) -> T) {
     value = action(value)
 }
 
-suspend fun MutableReactive<Boolean>.toggle() { set(!awaitOnce()) }
-fun MutableReactiveValue<Boolean>.toggle() { value = !value }
+public suspend fun MutableReactive<Boolean>.toggle() { set(!awaitOnce()) }
+public fun MutableReactiveValue<Boolean>.toggle() { value = !value }
 
 /**
  * Starts using this [ResourceUse] and tracks it as a dependency in future loops.
  * */
-fun DependencyTracker.use(resourceUse: ResourceUse) {
+public fun DependencyTracker.use(resourceUse: ResourceUse) {
     if (existingDependency(resourceUse) == null) {
         registerDependency(resourceUse, resourceUse.beginUse())
     }
@@ -116,7 +116,7 @@ fun DependencyTracker.use(resourceUse: ResourceUse) {
  * If this scope contains a [DependencyChangeListener] then the resource use
  * is attached as a dependency.
  * */
-fun CoroutineScope.use(resourceUse: ResourceUse) {
+public fun CoroutineScope.use(resourceUse: ResourceUse) {
     coroutineContext[DependencyChangeListener.Key]?.let {
         it.use(resourceUse)
         return
@@ -125,23 +125,23 @@ fun CoroutineScope.use(resourceUse: ResourceUse) {
     resourceUse.beginUse().also(::onRemove)
 }
 
-fun <T, WRITE : MutableReactive<T>> WRITE.interceptWrite(action: suspend WRITE.(T) -> Unit): MutableReactive<T> =
+public fun <T, WRITE : MutableReactive<T>> WRITE.interceptWrite(action: suspend WRITE.(T) -> Unit): MutableReactive<T> =
     object : MutableReactive<T>, Reactive<T> by this {
         override suspend fun set(value: T) {
             action(this@interceptWrite, value)
         }
     }
 
-fun <T> Reactive<Reactive<T>>.flatten(): Reactive<T> = remember { this@flatten()() }
+public fun <T> Reactive<Reactive<T>>.flatten(): Reactive<T> = remember { this@flatten()() }
 
-fun <T> Reactive<MutableReactive<T>>.flatten(): MutableReactive<T> =
+public fun <T> Reactive<MutableReactive<T>>.flatten(): MutableReactive<T> =
     remember { this@flatten()() }.withWrite {
         // awaitOnce rather than reading state: if the outer reactive is lazy it has no value to
         // read unless something is listening, and the write would be silently dropped.
         this@flatten.awaitOnce().set(it)
     }
 
-fun <T> CoroutineScope.asyncReactive(action: suspend () -> T): Reactive<T> {
+public fun <T> CoroutineScope.asyncReactive(action: suspend () -> T): Reactive<T> {
     val prop = LateInitSignal<T>()
     launch {
         prop.value = action()
@@ -150,7 +150,7 @@ fun <T> CoroutineScope.asyncReactive(action: suspend () -> T): Reactive<T> {
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)
-fun <T> Deferred<T>.toReactive() = object : BaseReactive<T>() {
+public fun <T> Deferred<T>.toReactive(): Reactive<T> = object : BaseReactive<T>() {
     init {
         this@toReactive[Job]?.invokeOnCompletion {
             state = if (it == null) ReactiveState(getCompleted()) else ReactiveState.exception(it as? Exception ?: Exception("Must be exception, not throwable", it))
@@ -158,15 +158,15 @@ fun <T> Deferred<T>.toReactive() = object : BaseReactive<T>() {
     }
 }
 
-suspend operator fun <R> (ReactiveContext.()->R).invoke(): R {
+public suspend operator fun <R> (ReactiveContext.()->R).invoke(): R {
     return remember { this@invoke() }.awaitOnce()
 }
-suspend operator fun <A, R> (ReactiveContext.(A)->R).invoke(a: A): R {
+public suspend operator fun <A, R> (ReactiveContext.(A)->R).invoke(a: A): R {
     return remember { this@invoke(a) }.awaitOnce()
 }
-suspend operator fun <A, B, R> (ReactiveContext.(A, B)->R).invoke(a: A, b: B): R {
+public suspend operator fun <A, B, R> (ReactiveContext.(A, B)->R).invoke(a: A, b: B): R {
     return remember { this@invoke(a, b) }.awaitOnce()
 }
-suspend operator fun <A, B, C, R> (ReactiveContext.(A, B, C)->R).invoke(a: A, b: B, c: C): R {
+public suspend operator fun <A, B, C, R> (ReactiveContext.(A, B, C)->R).invoke(a: A, b: B, c: C): R {
     return remember { this@invoke(a, b, c) }.awaitOnce()
 }

--- a/src/commonMain/kotlin/com/lightningkite/reactive/lensing/LensByElement.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/lensing/LensByElement.kt
@@ -14,42 +14,43 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlin.collections.plus
+import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.jvm.JvmName
 
-fun <E, ID, W> MutableReactive<List<E>>.lensByElementWithIdentity(
+public fun <E, ID, W> MutableReactive<List<E>>.lensByElementWithIdentity(
     identity: (E) -> ID,
     map: CoroutineScope.(MutableWithReactiveValue<E>) -> W
-) = LensByElement<E, ID, W>(this, identity = identity, elementLens = { it.map(it) })
+): LensByElement<E, ID, W> = LensByElement<E, ID, W>(this, identity = identity, elementLens = { it.map(it) })
 
-fun <E, ID> MutableReactive<List<E>>.lensByElementWithIdentity(
+public fun <E, ID> MutableReactive<List<E>>.lensByElementWithIdentity(
     identity: (E) -> ID
-) = LensElements<E, ID>(this, identity = identity, elementLens = { it })
+): LensElements<E, ID> = LensElements<E, ID>(this, identity = identity, elementLens = { it })
 
 @JvmName("setLensByElementWithIdentity")
 @Suppress("Deprecation")
-fun <E, ID, W> MutableReactive<Set<E>>.lensByElementWithIdentity(
+public fun <E, ID, W> MutableReactive<Set<E>>.lensByElementWithIdentity(
     identity: (E) -> ID,
     map: CoroutineScope.(MutableWithReactiveValue<E>) -> W
-) = lens(get = { it.toList() }, set = { it.toSet() }).lensByElement(identity, map)
+): LensByElement<E, ID, W> = lens(get = { it.toList() }, set = { it.toSet() }).lensByElement(identity, map)
 
 @JvmName("setLensByElementWithIdentity")
 @Suppress("Deprecation")
-fun <E, ID> MutableReactive<Set<E>>.lensByElementWithIdentity(
+public fun <E, ID> MutableReactive<Set<E>>.lensByElementWithIdentity(
     identity: (E) -> ID
-) = lens(get = { it.toList() }, set = { it.toSet() }).lensByElement(identity)
+): LensElements<E, ID> = lens(get = { it.toList() }, set = { it.toSet() }).lensByElement(identity)
 
 
-typealias LensElements<E, ID> = LensByElement<E, ID, LensByElement<E, ID, *>.Element>
+public typealias LensElements<E, ID> = LensByElement<E, ID, LensByElement<E, ID, *>.Element>
 
-class LensByElement<E, ID, T>(
-    val source: MutableReactive<List<E>>,
-    val identity: (E) -> ID,
-    val elementLens: (LensByElement<E, ID, T>.Element) -> T
+public class LensByElement<E, ID, T>(
+    public val source: MutableReactive<List<E>>,
+    public val identity: (E) -> ID,
+    public val elementLens: (LensByElement<E, ID, T>.Element) -> T
 ) : Reactive<List<T>> {
     private val node = IssueNode(parent = (source as? MutableValidated)?.node).apply { connect() }
 
-    inner class Element internal constructor(valueInit: E) : MutableWithReactiveValue<E>, MutableValidated<E>, CoroutineScope {
+    public inner class Element internal constructor(valueInit: E) : MutableWithReactiveValue<E>, MutableValidated<E>, CoroutineScope {
         override val node: IssueNode = this@LensByElement.node.child()
 
         private var job = Job()
@@ -58,7 +59,7 @@ class LensByElement<E, ID, T>(
                 Reactive.reportException(throwable)
             }
         }
-        override val coroutineContext get() = restOfContext + job
+        override val coroutineContext: CoroutineContext get() = restOfContext + job
 
         internal var dead = false
             set(value) {
@@ -68,7 +69,7 @@ class LensByElement<E, ID, T>(
                 job.cancel()
                 job = Job()
             }
-        var id: ID = identity(valueInit)
+        public var id: ID = identity(valueInit)
             private set
         private val listeners = ArrayList<() -> Unit>()
         override var value: E = valueInit
@@ -114,10 +115,10 @@ class LensByElement<E, ID, T>(
             }
         }
 
-        val view = elementLens(this)
+        public val view: T = elementLens(this)
     }
 
-    inner class Elements : MutableReactive<List<Element>> {
+    public inner class Elements : MutableReactive<List<Element>> {
         override suspend fun set(value: List<Element>) {
             source.set(value.map { it.queuedOrValue })
         }
@@ -178,22 +179,22 @@ class LensByElement<E, ID, T>(
         }
     }
 
-    val elements = Elements()
+    public val elements: Elements = Elements()
 
-    fun newElement(e: E): Element = Element(e)
-    suspend fun add(index: Int, value: E): T {
+    public fun newElement(e: E): Element = Element(e)
+    public suspend fun add(index: Int, value: E): T {
         val newly = newElement(value)
         elements.set(elements.awaitOnce().toMutableList().apply { add(index, newly) })
         return newly.view
     }
 
-    suspend fun add(value: E): T {
+    public suspend fun add(value: E): T {
         val newly = newElement(value)
         elements.set(elements.awaitOnce() + newly)
         return newly.view
     }
 
-    suspend fun upsert(value: E): T {
+    public suspend fun upsert(value: E): T {
         val id = identity(value)
         val existing = elements.awaitOnce().find { it.id == id }
         return if (existing == null) add(value) else {
@@ -202,12 +203,12 @@ class LensByElement<E, ID, T>(
         }
     }
 
-    suspend fun remove(element: E) {
+    public suspend fun remove(element: E) {
         val id = identity(element)
         removeById(id)
     }
 
-    suspend fun removeById(id: ID) {
+    public suspend fun removeById(id: ID) {
         elements.set(elements.awaitOnce().filter { it.id != id })
     }
 
@@ -219,21 +220,21 @@ class LensByElement<E, ID, T>(
 
 
 @Deprecated("Be specific about what kind you need.")
-fun <E, ID, W> MutableReactive<List<E>>.lensByElement(identity: (E) -> ID, map: CoroutineScope.(MutableWithReactiveValue<E>) -> W) =
+public fun <E, ID, W> MutableReactive<List<E>>.lensByElement(identity: (E) -> ID, map: CoroutineScope.(MutableWithReactiveValue<E>) -> W): LensByElement<E, ID, W> =
     LensByElement<E, ID, W>(this, identity = identity, elementLens = { it.map(it) })
 
 @Deprecated("Be specific about what kind you need.")
-fun <E, ID> MutableReactive<List<E>>.lensByElement(identity: (E) -> ID) =
+public fun <E, ID> MutableReactive<List<E>>.lensByElement(identity: (E) -> ID): LensElements<E, ID> =
     LensElements<E, ID>(this, identity = identity, elementLens = { it })
 
 @Deprecated("Be specific about what kind you need.")
 @JvmName("setLensByElement")
 @Suppress("Deprecation")
-fun <E, ID, W> MutableReactive<Set<E>>.lensByElement(identity: (E) -> ID, map: CoroutineScope.(MutableWithReactiveValue<E>) -> W) =
+public fun <E, ID, W> MutableReactive<Set<E>>.lensByElement(identity: (E) -> ID, map: CoroutineScope.(MutableWithReactiveValue<E>) -> W): LensByElement<E, ID, W> =
     lens(get = { it.toList() }, set = { it.toSet() }).lensByElement(identity, map)
 
 @Deprecated("Be specific about what kind you need.")
 @JvmName("setLensByElement")
 @Suppress("Deprecation")
-fun <E, ID> MutableReactive<Set<E>>.lensByElement(identity: (E) -> ID) =
+public fun <E, ID> MutableReactive<Set<E>>.lensByElement(identity: (E) -> ID): LensElements<E, ID> =
     lens(get = { it.toList() }, set = { it.toSet() }).lensByElement(identity)

--- a/src/commonMain/kotlin/com/lightningkite/reactive/lensing/LensByElementAssumingSetNeverManipulates.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/lensing/LensByElementAssumingSetNeverManipulates.kt
@@ -13,20 +13,20 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 
 
-interface MutableReactiveElement<E> : MutableWithReactiveValue<E> {
-    val index: ReactiveValue<Int>
+public interface MutableReactiveElement<E> : MutableWithReactiveValue<E> {
+    public val index: ReactiveValue<Int>
 }
 
 /**
  * THIS ONLY WORKS IF THE `set` on the receiver *never* manipulates the input before notifying.
  */
-fun <E> MutableReactive<List<E>>.lensByElementAssumingSetNeverManipulates(): Reactive<List<MutableReactiveElement<E>>> =
+public fun <E> MutableReactive<List<E>>.lensByElementAssumingSetNeverManipulates(): Reactive<List<MutableReactiveElement<E>>> =
     lensByElementAssumingSetNeverManipulates { it }
 
 /**
  * THIS ONLY WORKS IF THE `set` on the receiver *never* manipulates the input before notifying.
  */
-fun <E, W> MutableReactive<List<E>>.lensByElementAssumingSetNeverManipulates(map: CoroutineScope.(MutableReactiveElement<E>) -> W): Reactive<List<W>> =
+public fun <E, W> MutableReactive<List<E>>.lensByElementAssumingSetNeverManipulates(map: CoroutineScope.(MutableReactiveElement<E>) -> W): Reactive<List<W>> =
     LensByElementAssumingSetNeverManipulates(this, map)
 
 

--- a/src/commonMain/kotlin/com/lightningkite/reactive/lensing/abstracts.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/lensing/abstracts.kt
@@ -10,7 +10,7 @@ import com.lightningkite.reactive.core.Reactive
 import com.lightningkite.reactive.core.ReactiveState
 import com.lightningkite.reactive.core.ReactiveValue
 
-open class Lens<S : Reactive<T>, T, L>(val source: S, val get: (T) -> L) : BaseReactive<L>() {
+public open class Lens<S : Reactive<T>, T, L>(public val source: S, public val get: (T) -> L) : BaseReactive<L>() {
     override var state: ReactiveState<L>
         get() {
             if (myListen == null) super.state = source.state.map(get)
@@ -40,9 +40,9 @@ open class Lens<S : Reactive<T>, T, L>(val source: S, val get: (T) -> L) : BaseR
     }
 }
 
-open class SetLens<O, T>(
+public open class SetLens<O, T>(
     source: MutableReactive<O>, get: (O) -> T,
-    val set: (T) -> O
+    public val set: (T) -> O
 ) : Lens<MutableReactive<O>, O, T>(source, get), MutableReactive<T> {
     override suspend fun set(value: T) {
         val transformed = set.invoke(value)
@@ -51,10 +51,10 @@ open class SetLens<O, T>(
     }
 }
 
-open class ModifyLens<O, T>(
+public open class ModifyLens<O, T>(
     source: MutableReactive<O>,
     get: (O) -> T,
-    val modify: (O, T) -> O
+    public val modify: (O, T) -> O
 ) : Lens<MutableReactive<O>, O, T>(source, get), MutableReactive<T> {
     override suspend fun set(value: T) {
         val transformed = modify(source.awaitOnce(), value)
@@ -63,9 +63,9 @@ open class ModifyLens<O, T>(
     }
 }
 
-open class ValueLens<S : ReactiveValue<T>, T, L>(
-    val source: S,
-    val get: (T) -> L
+public open class ValueLens<S : ReactiveValue<T>, T, L>(
+    public val source: S,
+    public val get: (T) -> L
 ) : BaseReactiveValue<L>(source.value.let(get))  {
     override var value: L
         get() {
@@ -94,7 +94,7 @@ open class ValueLens<S : ReactiveValue<T>, T, L>(
     }
 }
 
-open class SetValueLens<O, T>(source: MutableReactiveValue<O>, get: (O) -> T, val set: (T) -> O) :
+public open class SetValueLens<O, T>(source: MutableReactiveValue<O>, get: (O) -> T, public val set: (T) -> O) :
     ValueLens<MutableReactiveValue<O>, O, T>(source, get), MutableReactiveValue<T> {
     override var value: T
         get() = super.value
@@ -105,7 +105,7 @@ open class SetValueLens<O, T>(source: MutableReactiveValue<O>, get: (O) -> T, va
         }
 }
 
-open class ModifyValueLens<O, T>(source: MutableReactiveValue<O>, get: (O) -> T, val modify: (O, T) -> O) :
+public open class ModifyValueLens<O, T>(source: MutableReactiveValue<O>, get: (O) -> T, public val modify: (O, T) -> O) :
     ValueLens<MutableReactiveValue<O>, O, T>(source, get), MutableReactiveValue<T> {
     override var value: T
         get() = super.value
@@ -116,10 +116,10 @@ open class ModifyValueLens<O, T>(source: MutableReactiveValue<O>, get: (O) -> T,
         }
 }
 
-fun <T, L> Reactive<T>.lens(get: (T) -> L): Reactive<L> = Lens(this, get)
-fun <T, L> ReactiveValue<T>.lens(get: (T) -> L): ReactiveValue<L> = ValueLens(this, get)
+public fun <T, L> Reactive<T>.lens(get: (T) -> L): Reactive<L> = Lens(this, get)
+public fun <T, L> ReactiveValue<T>.lens(get: (T) -> L): ReactiveValue<L> = ValueLens(this, get)
 
-fun <T> Listenable.lensListenable(
+public fun <T> Listenable.lensListenable(
     get: () -> T
 ): Reactive<T> = ValueLens(
     object: ReactiveValue<Unit>, Listenable by this {

--- a/src/commonMain/kotlin/com/lightningkite/reactive/lensing/validation/IssueNode.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/lensing/validation/IssueNode.kt
@@ -37,11 +37,11 @@ import com.lightningkite.reactive.core.remember
  *
  * @property parent The parent node in the validation tree, or null if this is the root.
  */
-class IssueNode(val parent: IssueNode? = null) : ResourceUse {
+public class IssueNode(public val parent: IssueNode? = null) : ResourceUse {
     private val nodeIssue = Signal<Reactive<Issue?>>(Constant(null))
 
-    fun report(issue: Issue?) { nodeIssue.value = Constant(issue) }
-    fun reactiveReport(issue: ReactiveContext.() -> Issue?) {
+    public fun report(issue: Issue?) { nodeIssue.value = Constant(issue) }
+    public fun reactiveReport(issue: ReactiveContext.() -> Issue?) {
         nodeIssue.value = remember(action = issue)
     }
 
@@ -58,7 +58,7 @@ class IssueNode(val parent: IssueNode? = null) : ResourceUse {
      * Instead, consider using [child] outside of the [ReactiveContext], and then report to that outside
      * node inside any reactive code.
      * */
-    fun child() = IssueNode(this).apply { connect() }
+    public fun child(): IssueNode = IssueNode(this).apply { connect() }
 
     private var connected = false
 
@@ -68,7 +68,7 @@ class IssueNode(val parent: IssueNode? = null) : ResourceUse {
      *
      * Useful for establishing validation dependencies once a set of data has become relevant.
      * */
-    fun connect() {
+    public fun connect() {
         if (connected || parent == null) return
         connected = true
         parent.children.add(this)
@@ -79,7 +79,7 @@ class IssueNode(val parent: IssueNode? = null) : ResourceUse {
      *
      * Useful for removing validation dependencies on data that is no longer relevant.
      * */
-    fun disconnect() {
+    public fun disconnect() {
         if (!connected || parent == null) return
         connected = false
         parent.children.remove(this)
@@ -90,7 +90,7 @@ class IssueNode(val parent: IssueNode? = null) : ResourceUse {
         return ::disconnect
     }
 
-    val issues : Reactive<List<Issue>> = remember {
+    public val issues : Reactive<List<Issue>> = remember {
         listOfNotNull(nodeIssue()()) + children().flatMap { it.issues() }
     }
 }
@@ -98,16 +98,16 @@ class IssueNode(val parent: IssueNode? = null) : ResourceUse {
 /**
  * Represents a validation issue, which can be either a warning or an invalid state.
  */
-sealed interface Issue {
-    val summary: String
-    val description: String
+public sealed interface Issue {
+    public val summary: String
+    public val description: String
 
     /**
      * Represents a warning issue. Does not necessarily prevent usage, but should be addressed.
      *
      * Values that result in an [Issue.Warning] being reported will still be used.
      */
-    data class Warning(
+    public data class Warning(
         override val summary: String,
         override val description: String = summary
     ) : Issue
@@ -118,7 +118,7 @@ sealed interface Issue {
      * Values that result in an [Issue.Invalid] being reported will be **discarded**.
      * I.e., if a lensed child of a [MutableValidated] reports [Issue.Invalid] on a value, it will not modify its parent.
      */
-    data class Invalid(
+    public data class Invalid(
         override val summary : String,
         override val description: String = summary
     ) : Issue

--- a/src/commonMain/kotlin/com/lightningkite/reactive/lensing/validation/Validated.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/lensing/validation/Validated.kt
@@ -35,14 +35,14 @@ import com.lightningkite.reactive.core.ReactiveValue
  *
  * @see Issue
  */
-interface IssueTracking {
-    val node: IssueNode
+public interface IssueTracking {
+    public val node: IssueNode
 }
 
 /**
  * Returns the current list of issues, this includes issues from this node and any child nodes.
  */
-val IssueTracking.issues get() = node.issues
+public val IssueTracking.issues: Reactive<List<Issue>> get() = node.issues
 
 /**
  * Reports a new issue to this node.
@@ -51,7 +51,7 @@ val IssueTracking.issues get() = node.issues
  *
  * @param issue The issue to report, or null to clear this node's issue.
  */
-fun IssueTracking.report(issue: Issue?) = node.report(issue)
+public fun IssueTracking.report(issue: Issue?): Unit = node.report(issue)
 
 /**
  * Represents a validated reactive value. See [IssueTracking] for more details about
@@ -60,7 +60,7 @@ fun IssueTracking.report(issue: Issue?) = node.report(issue)
  * @see IssueTracking
  * @see Reactive
  */
-interface Validated<T> : IssueTracking, Reactive<T>
+public interface Validated<T> : IssueTracking, Reactive<T>
 
 /**
  * Represents a validated reactive value with direct value access. See [IssueTracking] for more details about
@@ -69,7 +69,7 @@ interface Validated<T> : IssueTracking, Reactive<T>
  * @see IssueTracking
  * @see ReactiveValue
  */
-interface ValidatedValue<T> : IssueTracking, ReactiveValue<T>, Validated<T>
+public interface ValidatedValue<T> : IssueTracking, ReactiveValue<T>, Validated<T>
 
 /**
  * Represents a mutable validated reactive value.
@@ -77,7 +77,7 @@ interface ValidatedValue<T> : IssueTracking, ReactiveValue<T>, Validated<T>
  * Lensing a [MutableValidated] creates a child of this node in the validation tree.
  * See [IssueTracking] for more details about validation trees.
  */
-interface MutableValidated<T> : IssueTracking, MutableReactive<T>, Validated<T> {
+public interface MutableValidated<T> : IssueTracking, MutableReactive<T>, Validated<T> {
     /**
      * Creates a transforming lens for type conversion.
      * Returns a [MutableValidated] for the sub-value, preserving validation.
@@ -112,7 +112,7 @@ interface MutableValidated<T> : IssueTracking, MutableReactive<T>, Validated<T> 
  * @see IssueTracking
  * @see MutableReactiveValue
  */
-interface MutableValidatedValue<T> : IssueTracking, MutableReactiveValue<T>, ValidatedValue<T>, MutableValidated<T> {
+public interface MutableValidatedValue<T> : IssueTracking, MutableReactiveValue<T>, ValidatedValue<T>, MutableValidated<T> {
     /**
      * Creates a transforming lens for type conversion.
      * Returns a [MutableValidatedValue] for the sub-value, preserving validation.

--- a/src/commonMain/kotlin/com/lightningkite/reactive/lensing/validation/ValidatedDraft.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/lensing/validation/ValidatedDraft.kt
@@ -8,7 +8,7 @@ import com.lightningkite.reactive.core.Draft
  * @see Draft
  * @see MutableValidated
  * */
-interface ValidatedDraft<T> : Draft<T>, MutableValidated<T>
+public interface ValidatedDraft<T> : Draft<T>, MutableValidated<T>
 
 private class RootValidatedDraft<T>(val draft: Draft<T>, reportTo: IssueNode? = null) : ValidatedDraft<T>, Draft<T> by draft {
     override val node: IssueNode = reportTo?.child() ?: IssueNode()
@@ -17,4 +17,4 @@ private class RootValidatedDraft<T>(val draft: Draft<T>, reportTo: IssueNode? = 
     override fun <L> lens(get: (T) -> L, modify: (T, L) -> T): MutableValidated<L> = ValidatedModifyLens(this, get, modify)
 }
 
-fun <T> Draft<T>.validated(reportTo: IssueNode? = null): ValidatedDraft<T> = RootValidatedDraft(this, reportTo)
+public fun <T> Draft<T>.validated(reportTo: IssueNode? = null): ValidatedDraft<T> = RootValidatedDraft(this, reportTo)

--- a/src/commonMain/kotlin/com/lightningkite/reactive/lensing/validation/entrypoints.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/lensing/validation/entrypoints.kt
@@ -48,7 +48,7 @@ private class RootMutableValidatedValue<T>(
  *
  * @see IssueTracking
  */
-fun <T> Reactive<T>.validated(reportTo: IssueNode? = null): Validated<T> = this as? Validated<T> ?: RootValidated(this, reportTo)
+public fun <T> Reactive<T>.validated(reportTo: IssueNode? = null): Validated<T> = this as? Validated<T> ?: RootValidated(this, reportTo)
 
 /**
  * Wraps a [MutableReactive] as a [MutableValidated].
@@ -61,7 +61,7 @@ fun <T> Reactive<T>.validated(reportTo: IssueNode? = null): Validated<T> = this 
  *
  * @see IssueTracking
  */
-fun <T> MutableReactive<T>.validated(reportTo: IssueNode? = null): MutableValidated<T> = this as? MutableValidated<T> ?: RootMutableValidated(this, reportTo)
+public fun <T> MutableReactive<T>.validated(reportTo: IssueNode? = null): MutableValidated<T> = this as? MutableValidated<T> ?: RootMutableValidated(this, reportTo)
 
 /**
  * Wraps a [ReactiveValue] as a [ValidatedValue].
@@ -74,7 +74,7 @@ fun <T> MutableReactive<T>.validated(reportTo: IssueNode? = null): MutableValida
  *
  * @see IssueTracking
  */
-fun <T> ReactiveValue<T>.validated(reportTo: IssueNode? = null): ValidatedValue<T> = this as? ValidatedValue<T> ?: RootValidatedValue(this, reportTo)
+public fun <T> ReactiveValue<T>.validated(reportTo: IssueNode? = null): ValidatedValue<T> = this as? ValidatedValue<T> ?: RootValidatedValue(this, reportTo)
 
 /**
  * Wraps a [MutableReactiveValue] as a [MutableValidatedValue].
@@ -87,4 +87,4 @@ fun <T> ReactiveValue<T>.validated(reportTo: IssueNode? = null): ValidatedValue<
  *
  * @see IssueTracking
  */
-fun <T> MutableReactiveValue<T>.validated(reportTo: IssueNode? = null): MutableValidatedValue<T> = this as? MutableValidatedValue<T> ?: RootMutableValidatedValue(this, reportTo)
+public fun <T> MutableReactiveValue<T>.validated(reportTo: IssueNode? = null): MutableValidatedValue<T> = this as? MutableValidatedValue<T> ?: RootMutableValidatedValue(this, reportTo)

--- a/src/commonMain/kotlin/com/lightningkite/reactive/lensing/validation/helpers.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/lensing/validation/helpers.kt
@@ -14,10 +14,10 @@ import com.lightningkite.reactive.core.Signal
  * @param setOnIssue If true, issues are reported as [Issue.Warning]; if false, as [Issue.Invalid].
  * @param validate Function that returns a string issue message or null for valid values.
  */
-fun <T> MutableValidated<T>.validate(
+public fun <T> MutableValidated<T>.validate(
     setOnIssue: Boolean = true,
     validate: (T) -> String?
-) = checkForIssue { value ->
+): MutableValidated<T> = checkForIssue { value ->
     validate(value)?.let {
         if (setOnIssue) Issue.Warning(it)
         else Issue.Invalid(it)
@@ -33,10 +33,10 @@ fun <T> MutableValidated<T>.validate(
  * @param setOnIssue If true, issues are reported as [Issue.Warning]; if false, as [Issue.Invalid].
  * @param validate Function that returns a string issue message or null for valid values.
  */
-fun <T> MutableValidatedValue<T>.validate(
+public fun <T> MutableValidatedValue<T>.validate(
     setOnIssue: Boolean = true,
     validate: (T) -> String?
-) = checkForIssue { value ->
+): MutableValidatedValue<T> = checkForIssue { value ->
     validate(value)?.let {
         if (setOnIssue) Issue.Warning(it)
         else Issue.Invalid(it)
@@ -51,12 +51,12 @@ fun <T> MutableValidatedValue<T>.validate(
  * @param setOnIssue If true, issues are reported as [Issue.Warning]; if false, as [Issue.Invalid].
  * @param condition Function that returns true if valid, false if invalid.
  */
-fun <T> MutableValidated<T>.assert(
+public fun <T> MutableValidated<T>.assert(
     summary: String,
     description: String = summary,
     setOnIssue: Boolean = true,
     condition: (T) -> Boolean
-) = checkForIssue {
+): MutableValidated<T> = checkForIssue {
     if (condition(it)) return@checkForIssue null
 
     if (setOnIssue) Issue.Warning(summary, description)
@@ -71,12 +71,12 @@ fun <T> MutableValidated<T>.assert(
  * @param setOnIssue If true, issues are reported as [Issue.Warning]; if false, as [Issue.Invalid].
  * @param condition Function that returns true if valid, false if invalid.
  */
-fun <T> MutableValidatedValue<T>.assert(
+public fun <T> MutableValidatedValue<T>.assert(
     summary: String,
     description: String = summary,
     setOnIssue: Boolean = true,
     condition: (T) -> Boolean
-) = checkForIssue {
+): MutableValidatedValue<T> = checkForIssue {
     if (condition(it)) return@checkForIssue null
 
     if (setOnIssue) Issue.Warning(summary, description)
@@ -90,11 +90,11 @@ fun <T> MutableValidatedValue<T>.assert(
  * @param description Detailed description of the issue (defaults to [summary]).
  * @param setOnIssue If true, issues are reported as [Issue.Warning]; if false, as [Issue.Invalid].
  */
-fun <T : Any> MutableValidated<T?>.assertNotNull(
+public fun <T : Any> MutableValidated<T?>.assertNotNull(
     summary: String = "Cannot be blank",
     description: String = summary,
     setOnIssue: Boolean = true
-) = assert(summary, description, setOnIssue) { it != null }
+): MutableValidated<T?> = assert(summary, description, setOnIssue) { it != null }
 
 /**
  * Validates that the value of this [MutableValidatedValue] is not null.
@@ -103,11 +103,11 @@ fun <T : Any> MutableValidated<T?>.assertNotNull(
  * @param description Detailed description of the issue (defaults to [summary]).
  * @param setOnIssue If true, issues are reported as [Issue.Warning]; if false, as [Issue.Invalid].
  */
-fun <T : Any> MutableValidatedValue<T?>.assertNotNull(
+public fun <T : Any> MutableValidatedValue<T?>.assertNotNull(
     summary: String = "Cannot be blank",
     description: String = summary,
     setOnIssue: Boolean = true
-) = assert(summary, description, setOnIssue) { it != null }
+): MutableValidatedValue<T?> = assert(summary, description, setOnIssue) { it != null }
 
 /**
  * Validates that the value of this [MutableValidated] is not blank.
@@ -116,11 +116,11 @@ fun <T : Any> MutableValidatedValue<T?>.assertNotNull(
  * @param description Detailed description of the issue (defaults to [summary]).
  * @param setOnIssue If true, issues are reported as [Issue.Warning]; if false, as [Issue.Invalid].
  */
-fun MutableValidated<String>.assertNotBlank(
+public fun MutableValidated<String>.assertNotBlank(
     summary: String = "Cannot be blank",
     description: String = summary,
     setOnIssue: Boolean = true
-) = assert(summary, description, setOnIssue) { it.isNotBlank() }
+): MutableValidated<String> = assert(summary, description, setOnIssue) { it.isNotBlank() }
 
 /**
  * Validates that the value of this [MutableValidatedValue] is not blank.
@@ -129,11 +129,11 @@ fun MutableValidated<String>.assertNotBlank(
  * @param description Detailed description of the issue (defaults to [summary]).
  * @param setOnIssue If true, issues are reported as [Issue.Warning]; if false, as [Issue.Invalid].
  */
-fun MutableValidatedValue<String>.assertNotBlank(
+public fun MutableValidatedValue<String>.assertNotBlank(
     summary: String = "Cannot be blank",
     description: String = summary,
     setOnIssue: Boolean = true
-) = assert(summary, description, setOnIssue) { it.isNotBlank() }
+): MutableValidatedValue<String> = assert(summary, description, setOnIssue) { it.isNotBlank() }
 
 /**
  * Adds a validation check to this [MutableReactive] instance.
@@ -144,10 +144,10 @@ fun MutableValidatedValue<String>.assertNotBlank(
  * @param setOnIssue If true, issues are reported as [Issue.Warning]; if false, as [Issue.Invalid].
  * @param validate Function that returns a string issue message or null for valid values.
  */
-fun <T> MutableReactive<T>.validate(
+public fun <T> MutableReactive<T>.validate(
     setOnIssue: Boolean = true,
     validate: (T) -> String?
-) = checkForIssue { value ->
+): MutableValidated<T> = checkForIssue { value ->
     validate(value)?.let {
         if (setOnIssue) Issue.Warning(it)
         else Issue.Invalid(it)
@@ -163,10 +163,10 @@ fun <T> MutableReactive<T>.validate(
  * @param setOnIssue If true, issues are reported as [Issue.Warning]; if false, as [Issue.Invalid].
  * @param validate Function that returns a string issue message or null for valid values.
  */
-fun <T> MutableReactiveValue<T>.validate(
+public fun <T> MutableReactiveValue<T>.validate(
     setOnIssue: Boolean = true,
     validate: (T) -> String?
-) = checkForIssue { value ->
+): MutableValidatedValue<T> = checkForIssue { value ->
     validate(value)?.let {
         if (setOnIssue) Issue.Warning(it)
         else Issue.Invalid(it)
@@ -181,12 +181,12 @@ fun <T> MutableReactiveValue<T>.validate(
  * @param setOnIssue If true, issues are reported as [Issue.Warning]; if false, as [Issue.Invalid].
  * @param condition Function that returns true if valid, false if invalid.
  */
-fun <T> MutableReactive<T>.assert(
+public fun <T> MutableReactive<T>.assert(
     summary: String,
     description: String = summary,
     setOnIssue: Boolean = true,
     condition: (T) -> Boolean
-) = checkForIssue {
+): MutableValidated<T> = checkForIssue {
     if (condition(it)) return@checkForIssue null
 
     if (setOnIssue) Issue.Warning(summary, description)
@@ -201,12 +201,12 @@ fun <T> MutableReactive<T>.assert(
  * @param setOnIssue If true, issues are reported as [Issue.Warning]; if false, as [Issue.Invalid].
  * @param condition Function that returns true if valid, false if invalid.
  */
-fun <T> MutableReactiveValue<T>.assert(
+public fun <T> MutableReactiveValue<T>.assert(
     summary: String,
     description: String = summary,
     setOnIssue: Boolean = true,
     condition: (T) -> Boolean
-) = checkForIssue {
+): MutableValidatedValue<T> = checkForIssue {
     if (condition(it)) return@checkForIssue null
 
     if (setOnIssue) Issue.Warning(summary, description)
@@ -220,11 +220,11 @@ fun <T> MutableReactiveValue<T>.assert(
  * @param description Detailed description of the issue (defaults to [summary]).
  * @param setOnIssue If true, issues are reported as [Issue.Warning]; if false, as [Issue.Invalid].
  */
-fun <T : Any> MutableReactive<T?>.assertNotNull(
+public fun <T : Any> MutableReactive<T?>.assertNotNull(
     summary: String = "Cannot be blank",
     description: String = summary,
     setOnIssue: Boolean = true
-) = assert(summary, description, setOnIssue) { it != null }
+): MutableValidated<T?> = assert(summary, description, setOnIssue) { it != null }
 
 /**
  * Validates that the value of this [MutableReactiveValue] is not null.
@@ -233,11 +233,11 @@ fun <T : Any> MutableReactive<T?>.assertNotNull(
  * @param description Detailed description of the issue (defaults to [summary]).
  * @param setOnIssue If true, issues are reported as [Issue.Warning]; if false, as [Issue.Invalid].
  */
-fun <T : Any> MutableReactiveValue<T?>.assertNotNull(
+public fun <T : Any> MutableReactiveValue<T?>.assertNotNull(
     summary: String = "Cannot be blank",
     description: String = summary,
     setOnIssue: Boolean = true
-) = assert(summary, description, setOnIssue) { it != null }
+): MutableValidatedValue<T?> = assert(summary, description, setOnIssue) { it != null }
 
 /**
  * Validates that the value of this [MutableReactive] is not blank.
@@ -246,11 +246,11 @@ fun <T : Any> MutableReactiveValue<T?>.assertNotNull(
  * @param description Detailed description of the issue (defaults to [summary]).
  * @param setOnIssue If true, issues are reported as [Issue.Warning]; if false, as [Issue.Invalid].
  */
-fun MutableReactive<String>.assertNotBlank(
+public fun MutableReactive<String>.assertNotBlank(
     summary: String = "Cannot be blank",
     description: String = summary,
     setOnIssue: Boolean = true
-) = assert(summary, description, setOnIssue) { it.isNotBlank() }
+): MutableValidated<String> = assert(summary, description, setOnIssue) { it.isNotBlank() }
 
 /**
  * Validates that the value of this [MutableReactiveValue] is not blank.
@@ -259,16 +259,16 @@ fun MutableReactive<String>.assertNotBlank(
  * @param description Detailed description of the issue (defaults to [summary]).
  * @param setOnIssue If true, issues are reported as [Issue.Warning]; if false, as [Issue.Invalid].
  */
-fun MutableReactiveValue<String>.assertNotBlank(
+public fun MutableReactiveValue<String>.assertNotBlank(
     summary: String = "Cannot be blank",
     description: String = summary,
     setOnIssue: Boolean = true
-) = assert(summary, description, setOnIssue) { it.isNotBlank() }
+): MutableValidatedValue<String> = assert(summary, description, setOnIssue) { it.isNotBlank() }
 
 /**
  * Runs the provided validation condition reactively, reporting to a child of this [IssueTracking] node.
  * */
-fun IssueTracking.report(issue: ReactiveContext.() -> Issue?) {
+public fun IssueTracking.report(issue: ReactiveContext.() -> Issue?) {
     val child = IssueNode(parent = node)
     child.connect()
     child.reactiveReport(issue)
@@ -277,13 +277,13 @@ fun IssueTracking.report(issue: ReactiveContext.() -> Issue?) {
 /**
  * Runs the provided validation condition reactively, reporting to a child of this [IssueTracking] node.
  * */
-fun <T> Validated<T>.validateReactive(issue: ReactiveContext.(T) -> String?) = report { issue(this@validateReactive.invoke())?.let(Issue::Warning) }
+public fun <T> Validated<T>.validateReactive(issue: ReactiveContext.(T) -> String?): Unit = report { issue(this@validateReactive.invoke())?.let(Issue::Warning) }
 
 /**
  * Asserts the provided condition reactively, constructing and reporting an [Issue.Warning] to a child of this [IssueTracking] node.
  * */
-fun <T> Validated<T>.assertReactive(
+public fun <T> Validated<T>.assertReactive(
     summary: String,
     description: String = summary,
     condition: ReactiveContext.(T) -> Boolean
-) = report { if (condition(this@assertReactive.invoke())) null else Issue.Warning(summary, description) }
+): Unit = report { if (condition(this@assertReactive.invoke())) null else Issue.Warning(summary, description) }

--- a/src/commonMain/kotlin/com/lightningkite/reactive/lensing/validation/validation.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/lensing/validation/validation.kt
@@ -129,9 +129,9 @@ private class ValidationValueLens<T>(
         }
 }
 
-fun <T> Validated<T>.checkForIssue(validate: (T) -> Issue?): Validated<T> = ValidatedLens(this, validate)
+public fun <T> Validated<T>.checkForIssue(validate: (T) -> Issue?): Validated<T> = ValidatedLens(this, validate)
 
-fun <T> ValidatedValue<T>.checkForIssue(validate: (T) -> Issue?): ValidatedValue<T> = ValidatedValueLens(this, validate)
+public fun <T> ValidatedValue<T>.checkForIssue(validate: (T) -> Issue?): ValidatedValue<T> = ValidatedValueLens(this, validate)
 
 /**
  * Adds a validation check to a [MutableValidated] instance.
@@ -142,7 +142,7 @@ fun <T> ValidatedValue<T>.checkForIssue(validate: (T) -> Issue?): ValidatedValue
  * @param validate Function that returns an [Issue] or null for valid values.
  * @return A [MutableValidated] that tracks issues according to [validate].
  */
-fun <T> MutableValidated<T>.checkForIssue(validate: (T) -> Issue?): MutableValidated<T> = MutableValidationLens(this, validate)
+public fun <T> MutableValidated<T>.checkForIssue(validate: (T) -> Issue?): MutableValidated<T> = MutableValidationLens(this, validate)
 
 /**
  * Adds a validation check to a [MutableReactive] instance, returning a [MutableValidated] that tracks issues.
@@ -152,7 +152,7 @@ fun <T> MutableValidated<T>.checkForIssue(validate: (T) -> Issue?): MutableValid
  * @param validate Function that returns an [Issue] or null for valid values.
  * @return A [MutableValidated] that tracks issues according to [validate].
  */
-fun <T> MutableReactive<T>.checkForIssue(validate: (T) -> Issue?): MutableValidated<T> = MutableValidationLens(this.validated(), validate)
+public fun <T> MutableReactive<T>.checkForIssue(validate: (T) -> Issue?): MutableValidated<T> = MutableValidationLens(this.validated(), validate)
 
 
 /**
@@ -164,7 +164,7 @@ fun <T> MutableReactive<T>.checkForIssue(validate: (T) -> Issue?): MutableValida
  * @param validate Function that returns an [Issue] or null for valid values.
  * @return A [MutableValidatedValue] that tracks issues according to [validate].
  */
-fun <T> MutableValidatedValue<T>.checkForIssue(validate: (T) -> Issue?): MutableValidatedValue<T> = ValidationValueLens(this, validate)
+public fun <T> MutableValidatedValue<T>.checkForIssue(validate: (T) -> Issue?): MutableValidatedValue<T> = ValidationValueLens(this, validate)
 
 /**
  * Adds a validation check to a [MutableReactiveValue] instance, returning a [MutableValidatedValue] that tracks issues.
@@ -174,4 +174,4 @@ fun <T> MutableValidatedValue<T>.checkForIssue(validate: (T) -> Issue?): Mutable
  * @param validate Function that returns an [Issue] or null for valid values.
  * @return A [MutableValidatedValue] that tracks issues according to [validate].
  */
-fun <T> MutableReactiveValue<T>.checkForIssue(validate: (T) -> Issue?): MutableValidatedValue<T> = ValidationValueLens(this.validated(), validate)
+public fun <T> MutableReactiveValue<T>.checkForIssue(validate: (T) -> Issue?): MutableValidatedValue<T> = ValidationValueLens(this.validated(), validate)

--- a/src/commonMain/kotlin/com/lightningkite/reactive/lensing/validation/validationLenses.kt
+++ b/src/commonMain/kotlin/com/lightningkite/reactive/lensing/validation/validationLenses.kt
@@ -8,7 +8,7 @@ import com.lightningkite.reactive.lensing.ModifyValueLens
 import com.lightningkite.reactive.lensing.SetLens
 import com.lightningkite.reactive.lensing.SetValueLens
 
-class ValidatedSetLens<T, L>(
+public class ValidatedSetLens<T, L>(
     source: MutableValidated<T>,
     get: (T) -> L,
     set: (L) -> T
@@ -24,7 +24,7 @@ class ValidatedSetLens<T, L>(
     }
 }
 
-class ValidatedModifyLens<T, L>(
+public class ValidatedModifyLens<T, L>(
     source: MutableValidated<T>,
     get: (T) -> L,
     modify: (T, L) -> T
@@ -40,7 +40,7 @@ class ValidatedModifyLens<T, L>(
     }
 }
 
-class ValidatedSetValueLens<T, L>(
+public class ValidatedSetValueLens<T, L>(
     source: MutableValidatedValue<T>,
     get: (T) -> L,
     set: (L) -> T
@@ -56,7 +56,7 @@ class ValidatedSetValueLens<T, L>(
     }
 }
 
-class ValidatedModifyValueLens<T, L>(
+public class ValidatedModifyValueLens<T, L>(
     source: MutableValidatedValue<T>,
     get: (T) -> L,
     modify: (T, L) -> T


### PR DESCRIPTION
Turn on kotlin { explicitApi() } and add the visibility modifiers and explicit return types it requires across the public surface. No behavior changes.

The two added imports (CompletableJob, CoroutineContext) exist only to name types that were previously inferred.

jvmTest 113 tests green; JS + iOS compile green.


Claude-Session: https://claude.ai/code/session_017UHkALCCi6UrsGba6wUGWp